### PR TITLE
Added enforcement for all property setters based on the setAttribute mappings.

### DIFF
--- a/src/types/trustedscripturl.js
+++ b/src/types/trustedscripturl.js
@@ -20,7 +20,7 @@ limitations under the License.
 export class TrustedScriptURL {
   /**
    * @param {string} url The trusted URL.
-   */  
+   */
   constructor(url) {
     /**
      * The trusted URL.
@@ -35,19 +35,8 @@ export class TrustedScriptURL {
    * @return {!TrustedScriptURL}
    */
   static unsafelyCreate(url) {
-    let parsedUrl = TrustedScriptURL.parse_(url);
+    let parsedUrl = new URL(url, window.document.baseURI || undefined);
     return new TrustedScriptURL(parsedUrl.href);
-  }
-
-  /**
-   * Returns a parsed URL.
-   * @param {string} url The url to parse.
-   * @return {!HTMLAnchorElement} An anchor element containing the url.
-   */
-  static parse_(url) {
-    let aTag = /** @type !HTMLAnchorElement */ (document.createElement('a'));
-    aTag.href = url;
-    return aTag;
   }
 
   /**

--- a/src/types/trustedurl.js
+++ b/src/types/trustedurl.js
@@ -35,7 +35,7 @@ export class TrustedURL {
    * @return {!TrustedURL}
    */
   static unsafelyCreate(url) {
-    let parsedUrl = TrustedURL.parse_(url);
+    let parsedUrl = new URL(url, window.document.baseURI || undefined);
     return new TrustedURL(parsedUrl.href);
   }
 
@@ -46,23 +46,12 @@ export class TrustedURL {
    * @return {!TrustedURL}
    */
   static create(url) {
-    let parsedUrl = TrustedURL.parse_(url);
+    let parsedUrl = new URL(url, window.document.baseURI || undefined);
     if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
       return new TrustedURL('about:invalid');
     }
 
     return new TrustedURL(parsedUrl.href);
-  }
-
-  /**
-   * Returns a parsed URL.
-   * @param {string} url The url to parse.
-   * @return {!HTMLAnchorElement} An anchor element containing the url.
-   */
-  static parse_(url) {
-    let aTag = /** @type !HTMLAnchorElement */ (document.createElement('a'));
-    aTag.href = url;
-    return aTag;
   }
 
   /**

--- a/tests/enforcement_test.js
+++ b/tests/enforcement_test.js
@@ -126,6 +126,24 @@ describe('TrustedTypesEnforcer', function() {
       }).toThrow();
     });
 
+    it('on a href', function() {
+      let el = document.createElement('a');
+
+      expect(function() {
+        el.href = TEST_URL;
+      }).toThrow();
+    });
+
+    it('on object codebase', function() {
+      let el = document.createElement('object');
+
+      expect(function() {
+        el.setAttribute('codebase', TEST_URL);
+      }).toThrow();
+
+      expect(el.codeBase).toBe('');
+    });
+
     it('on Range.createContextualFragment', function() {
       let range = document.createRange();
 
@@ -158,6 +176,16 @@ describe('TrustedTypesEnforcer', function() {
 
       expect(function() {
         el.setAttribute('src', TEST_URL);
+      }).toThrow();
+
+      expect(el.src).toEqual('');
+    });
+
+    it('on non-lowercase Element.prototype.setAttribute', function() {
+      let el = document.createElement('iframe');
+
+      expect(function() {
+        el.setAttribute('SrC', TEST_URL);
       }).toThrow();
 
       expect(el.src).toEqual('');
@@ -264,6 +292,15 @@ describe('TrustedTypesEnforcer', function() {
       el.setAttribute('src', TrustedURL.unsafelyCreate(TEST_URL));
 
       expect(el.src).toEqual(TEST_URL);
+    });
+
+    it('on object codebase', function() {
+      let el = document.createElement('object');
+
+      el.setAttribute('codebase', TrustedScriptURL.unsafelyCreate(TEST_URL));
+
+      expect(el.codeBase).toBe(TEST_URL);
+      expect(el.codebase).toBe(undefined);
     });
   });
 });


### PR DESCRIPTION
Fixed a bypass with non-lowercase attribute names.
Fixed HTMLObjectElement.codeBase property assignment.