### PR TITLE
Added support for whitelisting policy names via CSP.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -15,8 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <head>
-  <meta http-equiv="Content-Security-Policy" content="tbd">
+  <meta http-equiv="Content-Security-Policy" content="trusted-types unsafe escape">
   <script src="../dist/trustedtypes.build.js"></script>
+
   <style>
     table {display: block; border-collapse: collapse;}
     td {border: 1px solid #888; padding: 0.5em;}
@@ -122,5 +123,9 @@ limitations under the License.
   runTest(['HTMLScriptElement.src', 'TrustedScriptURL'], function(el) {
     el.appendChild(document.createElement('script')).src = 'data:,';
   }, true);
+  runTest(['creating policy from outside whitelist'], function(el) {
+    TrustedTypes.createPolicy('foo', function() {});
+  }, true);
+
   </script>
 </body>

--- a/src/data/trustedtypeconfig.js
+++ b/src/data/trustedtypeconfig.js
@@ -25,8 +25,12 @@ export class TrustedTypeConfig {
    *   runtime.
    * @param {?string} fallbackPolicyName If present, direct DOM sink usage
    *   will be passed throught this policy (has to be exposed).
+   * @param {Array<string>} allowedPolicyNames Whitelisted policy names.
    */
-  constructor(isLoggingEnabled, isEnforcementEnabled, fallbackPolicyName) {
+  constructor(isLoggingEnabled,
+      isEnforcementEnabled,
+      fallbackPolicyName,
+      allowedPolicyNames) {
     /**
       * True if logging is enabled.
       * @type {boolean}
@@ -44,5 +48,50 @@ export class TrustedTypeConfig {
      * @type {?string}
      */
     this.fallbackPolicyName = fallbackPolicyName;
+
+    /**
+     * Allowed policy names.
+     * @type {Array<string>}
+     */
+    this.allowedPolicyNames = allowedPolicyNames;
+  }
+
+  /**
+   * Parses a CSP policy.
+   * @link https://www.w3.org/TR/CSP3/#parse-serialized-policy
+   * @param  {string} cspString String with a CSP definition.
+   * @return {Object<string,Array<string>>} Parsed CSP, keyed by directive
+   *   names.
+   */
+  static parseCSP(cspString) {
+    const SEMICOLON = /\s*;\s*/;
+    const WHITESPACE = /\s+/;
+    return cspString.trim().split(SEMICOLON)
+        .map((serializedDirective) => serializedDirective.split(WHITESPACE))
+        .reduce(function(parsed, directive) {
+          if (directive[0]) {
+            parsed[directive[0].toLowerCase()] = directive.slice(1).map(
+                (s) => s.toLowerCase())
+              .sort();
+          }
+          return parsed;
+        }, {});
+  }
+
+  /**
+   * Creates a TrustedTypeConfig object from a CSP string.
+   * @param  {string} cspString
+   * @return {!TrustedTypeConfig}
+   */
+  static fromCSP(cspString) {
+    const isLoggingEnabled = true;
+    const policy = TrustedTypeConfig.parseCSP(cspString);
+    const enforce = 'trusted-types' in policy;
+    return new TrustedTypeConfig(
+      isLoggingEnabled,
+      enforce, /* isEnforcementEnabled */
+      null, /* fallbackPolicyName */
+      enforce ? policy['trusted-types'] : ['*'] /* allowedPolicyNames */
+    );
   }
 }

--- a/src/enforcer.js
+++ b/src/enforcer.js
@@ -129,8 +129,10 @@ export class TrustedTypesEnforcer {
   /**
    * Wraps HTML sinks with an enforcement setter, which will enforce
    * trusted types and do logging, if enabled.
+   *
    */
   install() {
+    TrustedTypes.setAllowedPolicyNames(this.config_.allowedPolicyNames);
     this.wrapSetter_(Element.prototype, 'innerHTML', TrustedTypes.TrustedHTML);
     this.wrapSetter_(Element.prototype, 'outerHTML', TrustedTypes.TrustedHTML);
     this.wrapWithEnforceFunction_(Range.prototype, 'createContextualFragment',
@@ -152,6 +154,7 @@ export class TrustedTypesEnforcer {
     this.restoreFunction_(Element.prototype, 'setAttribute');
     this.restoreFunction_(Element.prototype, 'setAttributeNS');
     this.uninstallPropertySetWrappers_();
+    TrustedTypes.setAllowedPolicyNames(['*']);
   }
 
   /**

--- a/src/polyfill/api_only.js
+++ b/src/polyfill/api_only.js
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /**
- * @fileoverview Entry point for a polyfill that only uses the types
+ * @fileoverview Entry point for a polyfill that only defines the types
  * (i.e. no enforcement logic).
  */
 import {TrustedTypes as tt} from '../trustedtypes.js';
@@ -26,9 +26,6 @@ if (typeof window['TrustedTypes'] === 'undefined') {
     'TrustedHTML': tt.TrustedHTML,
     'TrustedURL': tt.TrustedURL,
     'TrustedScriptURL': tt.TrustedScriptURL,
-    'isHTML': tt.isHTML,
-    'isURL': tt.isURL,
-    'isScriptURL': tt.isScriptURL,
     'createHTML': tt.createHTML,
     'createURL': tt.createURL,
     'createScriptURL': tt.createScriptURL,

--- a/src/polyfill/full.js
+++ b/src/polyfill/full.js
@@ -25,13 +25,50 @@ import {TrustedTypes} from './api_only.js';
 /* eslint-enable no-unused-vars */
 
 /**
+ * Tries to guess a CSP policy from:
+ *  - the current polyfill script element text content (if prefixed with
+ *    "Content-Security-Policy:")
+ *  - the data-csp attribute value of the current script element.
+ *  - meta header
+ * @return {?string} Guessed CSP value, or null.
+ */
+function detectPolicy() {
+    try {
+        const currentScript = document.currentScript || (function() {
+          let scripts = document.getElementsByTagName('script');
+          return scripts[scripts.length - 1];
+        })();
+
+        const bodyPrefix = 'Content-Security-Policy:';
+        if (currentScript &&
+            currentScript.textContent.trim().substr(0, bodyPrefix.length) ==
+                bodyPrefix) {
+            return currentScript.textContent.trim().slice(bodyPrefix.length);
+        }
+        if (currentScript.dataset.csp) {
+            return currentScript.dataset.csp;
+        }
+        const cspInMeta = document.head.querySelector(
+            'meta[http-equiv^="Content-Security-Policy"]');
+        if (cspInMeta) {
+            return cspInMeta.content.trim();
+        }
+    } catch (e) {
+        return null;
+    }
+    return null;
+}
+
+/**
  * Bootstraps all trusted types polyfill and their enforcement.
  */
 export function bootstrap() {
-  const config = new TrustedTypeConfig(
+  const csp = detectPolicy();
+  const config = csp ? TrustedTypeConfig.fromCSP(csp) : new TrustedTypeConfig(
     /* isLoggingEnabled */ true,
     /* isEnforcementEnabled */ true,
-    /* fallbackPolicyName */ null);
+    /* fallbackPolicyName */ null,
+    /* allowedPolicyNames */ ['*']);
 
   const trustedTypesEnforcer = new TrustedTypesEnforcer(config);
 

--- a/tests/enforcer_test.js
+++ b/tests/enforcer_test.js
@@ -27,7 +27,8 @@ describe('TrustedTypesEnforcer', function() {
   let ENFORCING_CONFIG = new TrustedTypeConfig(
       /* isLoggingEnabled */ false,
       /* isEnforcementEnabled */ true,
-      /* fallbackPolicy */ null);
+      /* fallbackPolicy */ null,
+      /* allowedPolicyNames */ ['*']);
 
   describe('installation', function() {
     let enforcer;
@@ -440,6 +441,29 @@ describe('TrustedTypesEnforcer', function() {
     });
   });
 
+  describe('enforcement allowed policy names', function() {
+    let enforcer;
+
+    afterEach(function() {
+      enforcer.uninstall();
+    });
+
+    it('is respected on createPolicy', function() {
+      enforcer = new TrustedTypesEnforcer(new TrustedTypeConfig(
+      /* isLoggingEnabled */ false,
+      /* isEnforcementEnabled */ true,
+      'fallback1',
+      ['foo']));
+      enforcer.install();
+      expect(() => TrustedTypes.createPolicy('foo', (p) => {
+        p.createHTML = (s) => s;
+      })).not.toThrow();
+      expect(() => TrustedTypes.createPolicy('bar', (p) => {
+        p.createHTML = (s) => s;
+      })).toThrow();
+    });
+  });
+
   describe('enforcement fallback policy', function() {
     let enforcer;
 
@@ -451,7 +475,8 @@ describe('TrustedTypesEnforcer', function() {
       enforcer = new TrustedTypesEnforcer(new TrustedTypeConfig(
       /* isLoggingEnabled */ false,
       /* isEnforcementEnabled */ true,
-      'fallback1'));
+      'fallback1',
+      ['*']));
       enforcer.install();
       TrustedTypes.createPolicy('fallback1', (p) => {
         p.createHTML = (s) => 'fallback:' + s;
@@ -467,7 +492,7 @@ describe('TrustedTypesEnforcer', function() {
       enforcer = new TrustedTypesEnforcer(new TrustedTypeConfig(
       /* isLoggingEnabled */ false,
       /* isEnforcementEnabled */ true,
-      'fallback10'));
+      'fallback10', ['*']));
       enforcer.install();
       TrustedTypes.createPolicy('fallback10', (p) => {
         p.createHTML = (s) => 'fallback:' + s;
@@ -481,7 +506,7 @@ describe('TrustedTypesEnforcer', function() {
       enforcer = new TrustedTypesEnforcer(new TrustedTypeConfig(
       /* isLoggingEnabled */ false,
       /* isEnforcementEnabled */ true,
-      'fallback2'));
+      'fallback2', ['*']));
       enforcer.install();
       TrustedTypes.createPolicy('fallback2', (p) => {
         p.createHTML = (s) => 'fallback:' + s;
@@ -498,7 +523,7 @@ describe('TrustedTypesEnforcer', function() {
       enforcer = new TrustedTypesEnforcer(new TrustedTypeConfig(
       /* isLoggingEnabled */ false,
       /* isEnforcementEnabled */ true,
-      'fallback3'));
+      'fallback3', ['*']));
       enforcer.install();
       TrustedTypes.createPolicy(Math.random(), (p) => {});
       let el = document.createElement('div');

--- a/tests/trustedtypeconfig_test.js
+++ b/tests/trustedtypeconfig_test.js
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import {TrustedTypeConfig} from '../src/data/trustedtypeconfig.js';
+
+describe('TrustedTypeConfig', () => {
+  describe('parseCSP', () => {
+    it('parses policy with a single directive', () => {
+      const policy = `default-src 'self'`;
+      expect(TrustedTypeConfig.parseCSP(policy)).toEqual(
+          {'default-src': ['\'self\'']});
+    });
+
+    it('parses policy with a multiple directives', () => {
+      const policy = `default-src 'self'; connect-src http://foo.bar`;
+      expect(TrustedTypeConfig.parseCSP(policy)).toEqual({
+        'default-src': ['\'self\''],
+        'connect-src': ['http://foo.bar'],
+      });
+    });
+
+    it('ignores empty directives', () => {
+      const policy = `default-src 'self';; connect-src http://foo.bar`;
+      expect(TrustedTypeConfig.parseCSP(policy)).toEqual({
+        'default-src': [`'self'`],
+        'connect-src': ['http://foo.bar'],
+      });
+    });
+
+    it('makes the values lowercase', () => {
+      const policy = `DEFAult-src 'SELF'`;
+      expect(TrustedTypeConfig.parseCSP(policy)).toEqual({
+        'default-src': [`'self'`],
+      });
+    });
+
+    it('ignores whitespace', () => {
+      const policy = `\ndefault-src    'self';    \t connect-src\n\thttp://foo.bar  `;
+      expect(TrustedTypeConfig.parseCSP(policy)).toEqual({
+        'default-src': [`'self'`],
+        'connect-src': ['http://foo.bar'],
+      });
+    });
+
+    it('supports multiple directive values', () => {
+      const policy = `default-src 'self' https://a *; connect-src http://foo.bar`;
+      expect(TrustedTypeConfig.parseCSP(policy)).toEqual({
+        'default-src': [`'self'`, '*', 'https://a'],
+        'connect-src': ['http://foo.bar'],
+      });
+    });
+  });
+
+  describe('fromCSP', () => {
+    it('always enabled logging', () => {
+      expect(TrustedTypeConfig.fromCSP('').isLoggingEnabled).toBe(true);
+      expect(TrustedTypeConfig.fromCSP('trusted-types').isLoggingEnabled)
+        .toBe(true);
+    });
+
+    it('enforces iif trusted-types directive is present', () => {
+      expect(TrustedTypeConfig.fromCSP('').isEnforcementEnabled).toBe(false);
+      expect(TrustedTypeConfig.fromCSP('trusted-types').isEnforcementEnabled)
+        .toBe(true);
+    });
+
+    it('uses whitelisted directive names from the directive', () => {
+      expect(TrustedTypeConfig.fromCSP('trusted-types foo bar *')
+          .allowedPolicyNames).toEqual(['*', 'bar', 'foo']);
+    });
+
+    it('defaults to an empty set of allowed directives', () => {
+      expect(TrustedTypeConfig.fromCSP('trusted-types')
+          .allowedPolicyNames).toEqual([]);
+    });
+  });
+});

--- a/tests/trustedtypes_test.js
+++ b/tests/trustedtypes_test.js
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {TrustedTypes} from '../src/trustedtypes.js';
+import {TrustedTypes, trustedTypesBuilderTestOnly}
+  from '../src/trustedtypes.js';
 
 describe('v2 TrustedTypes', () => {
   let id = 0;
@@ -224,6 +225,31 @@ describe('v2 TrustedTypes', () => {
       const name = 'p' + id++;
       TrustedTypes.createPolicy(name, (p) => {});
       expect(() => TrustedTypes.createHTML(name, 'foo')).toThrow();
+    });
+  });
+
+  describe('setAllowedPolicyNames', () => {
+    let TrustedTypes;
+
+    beforeEach(() => {
+      // We need separate instances.
+       TrustedTypes = trustedTypesBuilderTestOnly();
+    });
+
+    it('is not applied by default', () => {
+      expect(() => TrustedTypes.createPolicy('foo', (p) => {})).not.toThrow();
+    });
+
+    it('is applied by createPolicy', () => {
+      TrustedTypes.setAllowedPolicyNames(['bar']);
+      expect(() => TrustedTypes.createPolicy('foo', (p) => {})).toThrow();
+      expect(() => TrustedTypes.createPolicy('bar', (p) => {})).not.toThrow();
+    });
+
+    it('supports wildcard', () => {
+      TrustedTypes.setAllowedPolicyNames(['*']);
+      expect(() => TrustedTypes.createPolicy('foo', (p) => {})).not.toThrow();
+      expect(() => TrustedTypes.createPolicy('bar', (p) => {})).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
The full polyfill detects the CSP present instead of relying on a hardcoded config.