### PR TITLE
typo

### DIFF
--- a/src/trustedtypes.js
+++ b/src/trustedtypes.js
@@ -317,7 +317,7 @@ export const trustedTypesBuilderTestOnly = function() {
     // Only copy own properties of names present in createTypeMapping.
     const innerPolicy = create(null);
     if (policy && typeof policy === 'object') {
-      // Treat non-objects are empty policies.
+      // Treat non-objects as empty policies.
       for (const key of getOwnPropertyNames(policy)) {
         if (createFunctionAllowed.call(createTypeMapping, key)) {
           innerPolicy[key] = policy[key];


### PR DESCRIPTION
Also, the term "non-object" is ambiguous around functions but not something that warrants a code change.