### PR TITLE
Replace TrustedURL with calling a default policy on navigation to javascript: URLs.

### DIFF
--- a/dist/spec/index.html
+++ b/dist/spec/index.html
@@ -2678,7 +2678,7 @@ of being rejected outright.</p>
     <li data-md>
      <p>If <var>defaultPolicy</var> is <code>null</code>, return <code>"Blocked"</code> and abort further steps.</p>
     <li data-md>
-     <p>Let <var>covertedScriptSource</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-trusted-type" id="ref-for-abstract-opdef-create-a-trusted-type④">Create a Trusted Type</a> algorithm, with the following arguments:</p>
+     <p>Let <var>convertedScriptSource</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-trusted-type" id="ref-for-abstract-opdef-create-a-trusted-type④">Create a Trusted Type</a> algorithm, with the following arguments:</p>
      <ul>
       <li data-md>
        <p><var>defaultPolicy</var> as <var>policy</var></p>
@@ -2690,7 +2690,7 @@ of being rejected outright.</p>
        <p>« <code>"Location.href"</code> » as <var>arguments</var></p>
      </ul>
     <li data-md>
-     <p>If <var>convertedScriptSource</var> does not have a type <code class="idl"><a data-link-type="idl" href="#trustedscript" id="ref-for-trustedscript①③">TrustedScript</a></code>, return <code>"Blocked"</code> and abort further steps.</p>
+     <p>If <var>convertedScriptSource</var> is not a <code class="idl"><a data-link-type="idl" href="#trustedscript" id="ref-for-trustedscript①③">TrustedScript</a></code> object, return <code>"Blocked"</code> and abort further steps.</p>
     <li data-md>
      <p>Set <var>urlString</var> to be the result of prepending <code>"javascript:"</code> to stringified <var>convertedScriptSource</var>.</p>
     <li data-md>

--- a/dist/spec/index.html
+++ b/dist/spec/index.html
@@ -1515,7 +1515,6 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#trusted-html"><span class="secno">2.2.1</span> <span class="content"><span>TrustedHTML</span></span></a>
         <li><a href="#trusted-script"><span class="secno">2.2.2</span> <span class="content"><span>TrustedScript</span></span></a>
         <li><a href="#trused-script-url"><span class="secno">2.2.3</span> <span class="content"><span>TrustedScriptURL</span></span></a>
-        <li><a href="#trusted-url"><span class="secno">2.2.4</span> <span class="content"><span>TrustedURL</span></span></a>
        </ol>
       <li>
        <a href="#policies"><span class="secno">2.3</span> <span class="content">Policies</span></a>
@@ -1548,11 +1547,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <ol class="toc">
         <li><a href="#extensions-to-the-window-interface"><span class="secno">4.1.1</span> <span class="content">Extensions to the Window interface</span></a>
         <li><a href="#extensions-to-the-document-interface"><span class="secno">4.1.2</span> <span class="content">Extensions to the Document interface</span></a>
-        <li><a href="#extensions-to-the-location-interface"><span class="secno">4.1.3</span> <span class="content">Extensions to the Location interface</span></a>
-        <li><a href="#enforcement-in-sinks"><span class="secno">4.1.4</span> <span class="content">Enforcement in element attributes</span></a>
-        <li><a href="#enforcement-in-script-text"><span class="secno">4.1.5</span> <span class="content">Enforcement for script text contents</span></a>
-        <li><a href="#enforcement-in-timer-functions"><span class="secno">4.1.6</span> <span class="content">Enforcement in timer functions</span></a>
-        <li><a href="#enforcement-in-event-handler-content-attributes"><span class="secno">4.1.7</span> <span class="content">Enforcement in event handler content attributes</span></a>
+        <li><a href="#enforcement-in-sinks"><span class="secno">4.1.3</span> <span class="content">Enforcement in element attributes</span></a>
+        <li><a href="#enforcement-in-script-text"><span class="secno">4.1.4</span> <span class="content">Enforcement for script text contents</span></a>
+        <li><a href="#enforcement-in-timer-functions"><span class="secno">4.1.5</span> <span class="content">Enforcement in timer functions</span></a>
+        <li><a href="#enforcement-in-event-handler-content-attributes"><span class="secno">4.1.6</span> <span class="content">Enforcement in event handler content attributes</span></a>
        </ol>
       <li><a href="#integration-with-svg"><span class="secno">4.2</span> <span class="content">Integration with SVG</span></a>
       <li>
@@ -1798,21 +1796,6 @@ string, constructed via a <code class="idl"><a data-link-type="idl" href="#trust
 USVString. The slot’s value is set when the object is created, and
 will never change during its lifetime.</p>
    <p>To stringify a TrustedScriptURL object, return the USVString from its <code>[[Data]]</code> internal slot.</p>
-   <h4 class="heading settled" data-level="2.2.4" id="trusted-url"><span class="secno">2.2.4. </span><span class="content"><dfn class="css" data-dfn-type="type" data-export id="typedef-trustedurl">TrustedURL<a class="self-link" href="#typedef-trustedurl"></a></dfn></span><a class="self-link" href="#trusted-url"></a></h4>
-   <p>The TrustedURL interface represents a string that a developer
-can confidently pass into an <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink⑥">injection sink</a> that may cause
-navigation to that URL string.
-These objects are immutable wrappers around a
-string, constructed via a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy③">TrustedTypePolicy</a></code>'s <code class="idl"><a data-link-type="idl">createURL</a></code> method.</p>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③"><c- g>Exposed</c-></a>=<c- n>Window</c->]
-<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="trustedurl"><code><c- g>TrustedURL</c-></code></dfn> {
-  <dfn data-dfn-for="TrustedURL" data-dfn-type="dfn" data-export data-lt="stringification behavior" id="TrustedURL-stringification-behavior"><c- b>stringifier</c-><a class="self-link" href="#TrustedURL-stringification-behavior"></a></dfn>;
-};
-</pre>
-   <p>TrustedURL objects have a <code>[[Data]]</code> internal slot which holds a
-USVString.  The slot’s value is set when the object is created, and
-will never change during its lifetime.</p>
-   <p>To stringify a TrustedURL object, return the USVString from its <code>[[Data]]</code> internal slot.</p>
    <h3 class="heading settled" data-level="2.3" id="policies"><span class="secno">2.3. </span><span class="content">Policies</span><a class="self-link" href="#policies"></a></h3>
    <p>Trusted Types can only be created via user-defined
 and immutable policies that define rules for converting a string into
@@ -1835,7 +1818,7 @@ myDiv<c- p>.</c->innerHTML <c- o>=</c-> sanitizingPolicy<c- p>.</c->createHTML<c
    </div>
    <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#trusted-type" id="ref-for-trusted-type">Trusted Type</a> objects wrap values that are explicitly trusted by
 the author. As such, creating a Trusted Type object instance becomes a de
-facto DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink⑦">injection sink</a>, and hence code that creates Trusted Type
+facto DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink⑥">injection sink</a>, and hence code that creates Trusted Type
 instances is security-critical. To allow for strict control over Trusted Type
 object creation we don’t expose the constructors of those
 directly, but require policy usage.</p>
@@ -1862,7 +1845,7 @@ myLibrary<c- p>.</c->init<c- p>({</c->policy<c- o>:</c-> cdnScriptsPolicy<c- p>}
 XSS, and hence call-sites of the policies' <code>create*</code> functions are the <em>only</em> security-sensitive code in the entire program. Only this
 typically small subset of the entire code base needs to be
 security-reviewed for DOM XSS - there’s no need to monitor or review
-the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink⑧">injection sinks</a> themselves, as User Agents <a data-link-type="dfn" href="#enforcement" id="ref-for-enforcement②">enforce</a> that
+the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink⑦">injection sinks</a> themselves, as User Agents <a data-link-type="dfn" href="#enforcement" id="ref-for-enforcement②">enforce</a> that
 those sinks will only accept Trusted Type objects, and these in turn
 can only be created via policies.</p>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-trustedtypepolicyfactory-createpolicy" id="ref-for-dom-trustedtypepolicyfactory-createpolicy">createPolicy</a></code> function returns a policy object which <code>create*</code> functions
@@ -1892,18 +1875,17 @@ that it’s called only with no attacker-controlled values.
 </pre>
    </div>
    <h4 class="heading settled" data-level="2.3.1" id="trusted-type-policy-factory"><span class="secno">2.3.1. </span><span class="content"><dfn class="css" data-dfn-type="type" data-export id="typedef-trustedtypepolicyfactory">TrustedTypePolicyFactory<a class="self-link" href="#typedef-trustedtypepolicyfactory"></a></dfn></span><a class="self-link" href="#trusted-type-policy-factory"></a></h4>
-   <p>TrustedTypePolicyFactory creates <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy④">policies</a></code> and verifies that Trusted Type object instances
+   <p>TrustedTypePolicyFactory creates <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy③">policies</a></code> and verifies that Trusted Type object instances
 were created via one of the policies.</p>
    <p class="note" role="note"><span>Note:</span> This factory object is exposed to JavaScript through <code>window.trustedTypes</code> reference - see <a href="#extensions-to-the-window-interface">§ 4.1.1 Extensions to the Window interface</a>.</p>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④"><c- g>Exposed</c-></a>=<c- n>Window</c->] <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="trustedtypepolicyfactory"><code><c- g>TrustedTypePolicyFactory</c-></code></dfn> {
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑤"><c- n>TrustedTypePolicy</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-createpolicy" id="ref-for-dom-trustedtypepolicyfactory-createpolicy②"><c- g>createPolicy</c-></a>(
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③"><c- g>Exposed</c-></a>=<c- n>Window</c->] <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="trustedtypepolicyfactory"><code><c- g>TrustedTypePolicyFactory</c-></code></dfn> {
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy④"><c- n>TrustedTypePolicy</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-createpolicy" id="ref-for-dom-trustedtypepolicyfactory-createpolicy②"><c- g>createPolicy</c-></a>(
         <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/createPolicy(policyName, policyOptions), TrustedTypePolicyFactory/createPolicy(policyName)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-createpolicy-policyname-policyoptions-policyname"><code><c- g>policyName</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-createpolicy-policyname-policyoptions-policyname"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-trustedtypepolicyoptions" id="ref-for-dictdef-trustedtypepolicyoptions"><c- n>TrustedTypePolicyOptions</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/createPolicy(policyName, policyOptions), TrustedTypePolicyFactory/createPolicy(policyName)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-createpolicy-policyname-policyoptions-policyoptions"><code><c- g>policyOptions</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-createpolicy-policyname-policyoptions-policyoptions"></a></dfn>);
     [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①"><c- g>Unforgeable</c-></a>] <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-getpolicynames" id="ref-for-dom-trustedtypepolicyfactory-getpolicynames"><c- g>getPolicyNames</c-></a>();
     [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable②"><c- g>Unforgeable</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-ishtml" id="ref-for-dom-trustedtypepolicyfactory-ishtml"><c- g>isHTML</c-></a>(<c- b>any</c-> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/isHTML(value)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-ishtml-value-value"><code><c- g>value</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-ishtml-value-value"></a></dfn>);
     [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable③"><c- g>Unforgeable</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-isscript" id="ref-for-dom-trustedtypepolicyfactory-isscript"><c- g>isScript</c-></a>(<c- b>any</c-> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/isScript(value)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-isscript-value-value"><code><c- g>value</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-isscript-value-value"></a></dfn>);
     [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable④"><c- g>Unforgeable</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-isscripturl" id="ref-for-dom-trustedtypepolicyfactory-isscripturl"><c- g>isScriptURL</c-></a>(<c- b>any</c-> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/isScriptURL(value)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-isscripturl-value-value"><code><c- g>value</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-isscripturl-value-value"></a></dfn>);
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑤"><c- g>Unforgeable</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-isurl" id="ref-for-dom-trustedtypepolicyfactory-isurl"><c- g>isURL</c-></a>(<c- b>any</c-> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/isURL(value)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-isurl-value-value"><code><c- g>value</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-isurl-value-value"></a></dfn>);
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑥"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①"><c- n>TrustedHTML</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="TrustedHTML" href="#dom-trustedtypepolicyfactory-emptyhtml" id="ref-for-dom-trustedtypepolicyfactory-emptyhtml"><c- g>emptyHTML</c-></a>;
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑤"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①"><c- n>TrustedHTML</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="TrustedHTML" href="#dom-trustedtypepolicyfactory-emptyhtml" id="ref-for-dom-trustedtypepolicyfactory-emptyhtml"><c- g>emptyHTML</c-></a>;
     <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a>? <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-getattributetype" id="ref-for-dom-trustedtypepolicyfactory-getattributetype"><c- g>getAttributeType</c-></a>(
         <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/getAttributeType(tagName, attribute, elementNs, attrNs), TrustedTypePolicyFactory/getAttributeType(tagName, attribute, elementNs), TrustedTypePolicyFactory/getAttributeType(tagName, attribute)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-getattributetype-tagname-attribute-elementns-attrns-tagname"><code><c- g>tagName</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-getattributetype-tagname-attribute-elementns-attrns-tagname"></a></dfn>,
         <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/getAttributeType(tagName, attribute, elementNs, attrNs), TrustedTypePolicyFactory/getAttributeType(tagName, attribute, elementNs), TrustedTypePolicyFactory/getAttributeType(tagName, attribute)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-getattributetype-tagname-attribute-elementns-attrns-attribute"><code><c- g>attribute</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-getattributetype-tagname-attribute-elementns-attrns-attribute"></a></dfn>,
@@ -1913,10 +1895,10 @@ were created via one of the policies.</p>
         <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/getPropertyType(tagName, property, elementNs), TrustedTypePolicyFactory/getPropertyType(tagName, property)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-getpropertytype-tagname-property-elementns-tagname"><code><c- g>tagName</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-getpropertytype-tagname-property-elementns-tagname"></a></dfn>,
         <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑨"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/getPropertyType(tagName, property, elementNs), TrustedTypePolicyFactory/getPropertyType(tagName, property)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-getpropertytype-tagname-property-elementns-property"><code><c- g>property</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-getpropertytype-tagname-property-elementns-property"></a></dfn>,
         <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⓪"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicyFactory/getPropertyType(tagName, property, elementNs), TrustedTypePolicyFactory/getPropertyType(tagName, property)" data-dfn-type="argument" data-export id="dom-trustedtypepolicyfactory-getpropertytype-tagname-property-elementns-elementns"><code><c- g>elementNs</c-></code><a class="self-link" href="#dom-trustedtypepolicyfactory-getpropertytype-tagname-property-elementns-elementns"></a></dfn> = "");
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑥"><c- n>TrustedTypePolicy</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="TrustedTypePolicy?" href="#dom-trustedtypepolicyfactory-defaultpolicy" id="ref-for-dom-trustedtypepolicyfactory-defaultpolicy"><c- g>defaultPolicy</c-></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑤"><c- n>TrustedTypePolicy</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="TrustedTypePolicy?" href="#dom-trustedtypepolicyfactory-defaultpolicy" id="ref-for-dom-trustedtypepolicyfactory-defaultpolicy"><c- g>defaultPolicy</c-></a>;
 };
 </pre>
-   <p>Internal slot <code>[[DefaultPolicy]]</code> may contain a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑦">TrustedTypePolicy</a></code> object,
+   <p>Internal slot <code>[[DefaultPolicy]]</code> may contain a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑥">TrustedTypePolicy</a></code> object,
 and is initially empty.</p>
    <p>Internal slot <code>[[CreatedPolicyNames]]</code> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">ordered set</a> of strings,
 initially empty.</p>
@@ -2006,9 +1988,6 @@ trustedTypes<c- p>.</c->isHTML<c- p>(</c-><c- u>"&lt;div>plain string&lt;/div>"<
      <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicyFactory" data-dfn-type="method" data-export id="dom-trustedtypepolicyfactory-isscripturl"><code>isScriptURL(value)</code></dfn>
      <dd data-md>
       <p>Returns true if value is an instance of <code class="idl"><a data-link-type="idl" href="#trustedscripturl" id="ref-for-trustedscripturl">TrustedScriptURL</a></code> and has its <code>[[Data]]</code> internal slot set, false otherwise.</p>
-     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicyFactory" data-dfn-type="method" data-export id="dom-trustedtypepolicyfactory-isurl"><code>isURL(value)</code></dfn>
-     <dd data-md>
-      <p>Returns true if value is an instance of <code class="idl"><a data-link-type="idl" href="#trustedurl" id="ref-for-trustedurl">TrustedURL</a></code> and has its <code>[[Data]]</code> internal slot set, false otherwise.</p>
      <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicyFactory" data-dfn-type="method" data-export data-lt="getPropertyType(tagName, property, elementNs)|getPropertyType(tagName, property)" id="dom-trustedtypepolicyfactory-getpropertytype"><code>getPropertyType(tagName, property, elementNs)</code></dfn>
      <dd data-md>
       <p>Allows the authors to check if a Trusted Type is required for a given <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-namednodemap-element" id="ref-for-concept-namednodemap-element">Element</a>'s
@@ -2031,7 +2010,6 @@ stringified <code class="idl"><a data-link-type="idl" href="#extendedattrdef-tru
       <div class="example" id="get-property-type-example">
        <a class="self-link" href="#get-property-type-example"></a> 
 <pre class="highlight">trustedTypes<c- p>.</c->getPropertyType<c- p>(</c-><c- t>'div'</c-><c- p>,</c-> <c- t>'innerHTML'</c-><c- p>);</c-> <c- c1>// "TrustedHTML"</c->
-trustedTypes<c- p>.</c->getPropertyType<c- p>(</c-><c- t>'form'</c-><c- p>,</c-> <c- t>'formAction'</c-><c- p>);</c-> <c- c1>// "TrustedURL"</c->
 trustedTypes<c- p>.</c->getPropertyType<c- p>(</c-><c- t>'foo'</c-><c- p>,</c-> <c- t>'bar'</c-><c- p>);</c-> <c- c1>// undefined</c->
 </pre>
       </div>
@@ -2063,9 +2041,8 @@ stringified <code class="idl"><a data-link-type="idl" href="#extendedattrdef-tru
       </ol>
       <div class="example" id="get-attribute-type-example">
        <a class="self-link" href="#get-attribute-type-example"></a> 
-<pre class="highlight">trustedTypes<c- p>.</c->getPropertyType<c- p>(</c-><c- t>'a'</c-><c- p>,</c-> <c- t>'HREF'</c-><c- p>);</c-> <c- c1>// "TrustedURL"</c->
-trustedTypes<c- p>.</c->getPropertyType<c- p>(</c-><c- t>'form'</c-><c- p>,</c-> <c- t>'formaction'</c-><c- p>);</c-> <c- c1>// "TrustedURL"</c->
-trustedTypes<c- p>.</c->getPropertyType<c- p>(</c-><c- t>'foo'</c-><c- p>,</c-> <c- t>'bar'</c-><c- p>);</c-> <c- c1>// undefined</c->
+<pre class="highlight">trustedTypes<c- p>.</c->getAttributeType<c- p>(</c-><c- t>'script'</c-><c- p>,</c-> <c- t>'SRC'</c-><c- p>);</c-> <c- c1>// "TrustedScriptURL"</c->
+trustedTypes<c- p>.</c->getAttributeType<c- p>(</c-><c- t>'foo'</c-><c- p>,</c-> <c- t>'bar'</c-><c- p>);</c-> <c- c1>// undefined</c->
 </pre>
       </div>
     </dl>
@@ -2082,7 +2059,7 @@ trustedTypes<c- p>.</c->getPropertyType<c- p>(</c-><c- t>'foo'</c-><c- p>,</c-> 
 </pre>
     </div>
     <dl>
-     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicyFactory" data-dfn-type="attribute" data-export id="dom-trustedtypepolicyfactory-defaultpolicy"><code>defaultPolicy</code></dfn>, <span> of type <a data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑧">TrustedTypePolicy</a>, readonly, nullable</span>
+     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicyFactory" data-dfn-type="attribute" data-export id="dom-trustedtypepolicyfactory-defaultpolicy"><code>defaultPolicy</code></dfn>, <span> of type <a data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑦">TrustedTypePolicy</a>, readonly, nullable</span>
      <dd data-md>
       <p>Returns the value of <code>[[DefaultPolicy]]</code> internal slot, or null if the slot is empty.</p>
     </dl>
@@ -2099,13 +2076,12 @@ trustedTypes<c- p>.</c->defaultPolicy <c- o>===</c-> dp<c- p>;</c->  <c- c1>// t
 group of functions creating Trusted Type objects.
 Each of the <code>create*</code> functions converts a string value to a given Trusted Type variant, or
 throws a TypeError if a conversion of a given value is disallowed.</p>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="trustedtypepolicy"><code><c- g>TrustedTypePolicy</c-></code></dfn> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑦"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicy" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-trustedtypepolicy-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-trustedtypepolicy-name"></a></dfn>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑧"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑤"><c- n>TrustedHTML</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createhtml" id="ref-for-dom-trustedtypepolicy-createhtml"><c- g>createHTML</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createHTML(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createhtml-input-arguments-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createhtml-input-arguments-input"></a></dfn>, <c- b>any</c->... <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createHTML(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createhtml-input-arguments-arguments"><code><c- g>arguments</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createhtml-input-arguments-arguments"></a></dfn>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑨"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript①"><c- n>TrustedScript</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscript" id="ref-for-dom-trustedtypepolicy-createscript"><c- g>createScript</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①③"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createScript(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createscript-input-arguments-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createscript-input-arguments-input"></a></dfn>, <c- b>any</c->... <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createScript(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createscript-input-arguments-arguments"><code><c- g>arguments</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createscript-input-arguments-arguments"></a></dfn>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①⓪"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl①"><c- n>TrustedScriptURL</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscripturl" id="ref-for-dom-trustedtypepolicy-createscripturl"><c- g>createScriptURL</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createScriptURL(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createscripturl-input-arguments-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createscripturl-input-arguments-input"></a></dfn>, <c- b>any</c->... <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createScriptURL(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createscripturl-input-arguments-arguments"><code><c- g>arguments</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createscripturl-input-arguments-arguments"></a></dfn>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①"><c- n>TrustedURL</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createurl" id="ref-for-dom-trustedtypepolicy-createurl"><c- g>createURL</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑤"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createURL(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createurl-input-arguments-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createurl-input-arguments-input"></a></dfn>, <c- b>any</c->... <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createURL(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createurl-input-arguments-arguments"><code><c- g>arguments</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createurl-input-arguments-arguments"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑥"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicy" data-dfn-type="attribute" data-export data-readonly data-type="DOMString" id="dom-trustedtypepolicy-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-trustedtypepolicy-name"></a></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑦"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑤"><c- n>TrustedHTML</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createhtml" id="ref-for-dom-trustedtypepolicy-createhtml"><c- g>createHTML</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createHTML(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createhtml-input-arguments-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createhtml-input-arguments-input"></a></dfn>, <c- b>any</c->... <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createHTML(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createhtml-input-arguments-arguments"><code><c- g>arguments</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createhtml-input-arguments-arguments"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑧"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript①"><c- n>TrustedScript</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscript" id="ref-for-dom-trustedtypepolicy-createscript"><c- g>createScript</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①③"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createScript(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createscript-input-arguments-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createscript-input-arguments-input"></a></dfn>, <c- b>any</c->... <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createScript(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createscript-input-arguments-arguments"><code><c- g>arguments</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createscript-input-arguments-arguments"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑨"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl①"><c- n>TrustedScriptURL</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscripturl" id="ref-for-dom-trustedtypepolicy-createscripturl"><c- g>createScriptURL</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createScriptURL(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createscripturl-input-arguments-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createscripturl-input-arguments-input"></a></dfn>, <c- b>any</c->... <dfn class="idl-code" data-dfn-for="TrustedTypePolicy/createScriptURL(input, ...arguments)" data-dfn-type="argument" data-export id="dom-trustedtypepolicy-createscripturl-input-arguments-arguments"><code><c- g>arguments</c-></code><a class="self-link" href="#dom-trustedtypepolicy-createscripturl-input-arguments-arguments"></a></dfn>);
 };
 </pre>
    <p>Each policy has a <dfn class="dfn-paneled" data-dfn-for="TrustedTypePolicy" data-dfn-type="dfn" data-noexport id="trustedtypepolicy-name">name</dfn>.</p>
@@ -2157,41 +2133,24 @@ following arguments:</p>
        <dt>arguments
        <dd>arguments
       </dl>
-     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicy" data-dfn-type="method" data-export id="dom-trustedtypepolicy-createurl"><code>createURL(input, ...arguments)</code></dfn>
-     <dd data-md>
-      <p>Returns the
-result of executing the <a data-link-type="abstract-op" href="#abstract-opdef-create-a-trusted-type" id="ref-for-abstract-opdef-create-a-trusted-type③">Create a Trusted Type</a> algorithm, with the
-following arguments:</p>
-      <dl>
-       <dt>policy
-       <dd><a href="https://dom.spec.whatwg.org/#context-object">context object</a> 
-       <dt>trustedTypeName
-       <dd><code>"TrustedURL"</code>
-       <dt>value
-       <dd>input
-       <dt>arguments
-       <dd>arguments
-      </dl>
     </dl>
    </div>
    <h4 class="heading settled" data-level="2.3.3" id="trusted-type-policy-options"><span class="secno">2.3.3. </span><span class="content"><dfn class="css" data-dfn-type="type" data-export id="typedef-trustedtypepolicyoptions">TrustedTypePolicyOptions<a class="self-link" href="#typedef-trustedtypepolicyoptions"></a></dfn></span><a class="self-link" href="#trusted-type-policy-options"></a></h4>
    <p>This dictionary holds author-defined functions for converting string
-values into trusted values. These functions do not create <a data-link-type="dfn" href="#trusted-type" id="ref-for-trusted-type②">Trusted Type</a> object instances directly - this behavior is provided by <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑨">TrustedTypePolicy</a></code>.</p>
+values into trusted values. These functions do not create <a data-link-type="dfn" href="#trusted-type" id="ref-for-trusted-type②">Trusted Type</a> object instances directly - this behavior is provided by <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑧">TrustedTypePolicy</a></code>.</p>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-trustedtypepolicyoptions"><code><c- g>TrustedTypePolicyOptions</c-></code></dfn> {
    <a class="n" data-link-type="idl-name" href="#callbackdef-createhtmlcallback" id="ref-for-callbackdef-createhtmlcallback"><c- n>CreateHTMLCallback</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicyOptions" data-dfn-type="dict-member" data-export data-type="CreateHTMLCallback? " id="dom-trustedtypepolicyoptions-createhtml"><code><c- g>createHTML</c-></code></dfn>;
    <a class="n" data-link-type="idl-name" href="#callbackdef-createscriptcallback" id="ref-for-callbackdef-createscriptcallback"><c- n>CreateScriptCallback</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicyOptions" data-dfn-type="dict-member" data-export data-type="CreateScriptCallback? " id="dom-trustedtypepolicyoptions-createscript"><code><c- g>createScript</c-></code></dfn>;
-   <a class="n" data-link-type="idl-name" href="#callbackdef-createurlcallback" id="ref-for-callbackdef-createurlcallback"><c- n>CreateURLCallback</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicyOptions" data-dfn-type="dict-member" data-export data-type="CreateURLCallback? " id="dom-trustedtypepolicyoptions-createurl"><code><c- g>createURL</c-></code></dfn>;
    <a class="n" data-link-type="idl-name" href="#callbackdef-createscripturlcallback" id="ref-for-callbackdef-createscripturlcallback"><c- n>CreateScriptURLCallback</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="TrustedTypePolicyOptions" data-dfn-type="dict-member" data-export data-type="CreateScriptURLCallback? " id="dom-trustedtypepolicyoptions-createscripturl"><code><c- g>createScriptURL</c-></code></dfn>;
 };
-<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-createhtmlcallback"><code><c- g>CreateHTMLCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑥"><c- b>DOMString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑦"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CreateHTMLCallback" data-dfn-type="argument" data-export id="dom-createhtmlcallback-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-createhtmlcallback-input"></a></dfn>);
-<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-createscriptcallback"><code><c- g>CreateScriptCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑧"><c- b>DOMString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑨"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CreateScriptCallback" data-dfn-type="argument" data-export id="dom-createscriptcallback-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-createscriptcallback-input"></a></dfn>);
-<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-createurlcallback"><code><c- g>CreateURLCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⓪"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CreateURLCallback" data-dfn-type="argument" data-export id="dom-createurlcallback-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-createurlcallback-input"></a></dfn>);
-<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-createscripturlcallback"><code><c- g>CreateScriptURLCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CreateScriptURLCallback" data-dfn-type="argument" data-export id="dom-createscripturlcallback-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-createscripturlcallback-input"></a></dfn>);
+<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-createhtmlcallback"><code><c- g>CreateHTMLCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑤"><c- b>DOMString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑥"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CreateHTMLCallback" data-dfn-type="argument" data-export id="dom-createhtmlcallback-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-createhtmlcallback-input"></a></dfn>);
+<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-createscriptcallback"><code><c- g>CreateScriptCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑦"><c- b>DOMString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑧"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CreateScriptCallback" data-dfn-type="argument" data-export id="dom-createscriptcallback-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-createscriptcallback-input"></a></dfn>);
+<c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-createscripturlcallback"><code><c- g>CreateScriptURLCallback</c-></code></dfn> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑨"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CreateScriptURLCallback" data-dfn-type="argument" data-export id="dom-createscripturlcallback-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-createscripturlcallback-input"></a></dfn>);
 </pre>
    <h4 class="heading settled" data-level="2.3.4" id="default-policy-hdr"><span class="secno">2.3.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="default-policy">Default policy</dfn></span><a class="self-link" href="#default-policy-hdr"></a></h4>
    <p><em>This section is not normative.</em></p>
    <p>One of the policies, the policy with a <a data-link-type="dfn" href="#trustedtypepolicy-name" id="ref-for-trustedtypepolicy-name">name</a> <code>"default"</code>, is special;
-When an <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink⑨">injection sink</a> is passed a string (instead of a
+When an <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink⑧">injection sink</a> is passed a string (instead of a
 Trusted Type object), this policy will be implicitly called by
 the user agent with the string value as the first argument, and the sink name
 as a second argument.</p>
@@ -2232,9 +2191,9 @@ console<c- p>.</c->log<c- p>(</c->aScriptElement<c- p>.</c->src<c- p>);</c->
    </div>
    <h3 class="heading settled" data-level="2.4" id="enforcement-hdr"><span class="secno">2.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="enforcement">Enforcement</dfn></span><a class="self-link" href="#enforcement-hdr"></a></h3>
    <p class="note" role="note"><span>Note:</span> Enforcement is the process of checking that a value
-has an appropriate type before it reaches an <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⓪">injection sink</a>.</p>
+has an appropriate type before it reaches an <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink⑨">injection sink</a>.</p>
    <p>The JavaScript API that allows authors to create policies and Trusted Types objects from them is always
-available (via <code class="idl"><a data-link-type="idl" href="#dom-window-trustedtypes" id="ref-for-dom-window-trustedtypes">trustedTypes</a></code>). Since <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①①">injection sinks</a> stringify their security sensitive
+available (via <code class="idl"><a data-link-type="idl" href="#dom-window-trustedtypes" id="ref-for-dom-window-trustedtypes">trustedTypes</a></code>). Since <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⓪">injection sinks</a> stringify their security sensitive
 arguments, and <a data-link-type="dfn" href="#trusted-type" id="ref-for-trusted-type③">Trusted Type</a> objects stringify to their inner string values, this allows the authors
 to use Trusted Types in place of strings.</p>
    <p>To prevent DOM XSS, on top of the JavaScript code using the Trusted Types, the user agent needs to enforce them i.e.
@@ -2248,10 +2207,10 @@ via using the <code class="idl"><a data-link-type="idl">Content-Security-Report-
 algorithms in other specifiactions, see <a href="#integrations">§ 4 Integrations</a>.</p>
    <h4 class="heading settled" data-level="2.4.2" id="!trustedtypes-extended-attribute"><span class="secno">2.4.2. </span><span class="content">TrustedTypes extended attribute</span><a class="self-link" href="#!trustedtypes-extended-attribute"></a></h4>
    <p class="note" role="note"><span>Note:</span> This section describes the implementation details of the Trusted Types mechanism. IDL extended attributes are not exposed to the JavasScript code.</p>
-   <p>To annotate the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①②">injection sink</a> functions that require Trusted Types, we introduce <dfn class="dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export data-lt="TrustedTypes" data-x="TrustedTypes" id="extendedattrdef-trustedtypes"><code>[TrustedTypes]</code></dfn> IDL <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-extended-attribute" id="ref-for-dfn-extended-attribute">extended attribute</a>. Its presence indicates that the relevant construct is to be supplemented with additional
+   <p>To annotate the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①①">injection sink</a> functions that require Trusted Types, we introduce <dfn class="dfn-paneled idl-code" data-dfn-type="extended-attribute" data-export data-lt="TrustedTypes" data-x="TrustedTypes" id="extendedattrdef-trustedtypes"><code>[TrustedTypes]</code></dfn> IDL <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-extended-attribute" id="ref-for-dfn-extended-attribute">extended attribute</a>. Its presence indicates that the relevant construct is to be supplemented with additional
 Trusted Types enforcement logic.</p>
    <p>The <code class="idl"><a data-link-type="idl" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes④">TrustedTypes</a></code> extended attribute <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-xattr-identifier" id="ref-for-dfn-xattr-identifier">takes an identifier</a> as an argument.
-The only valid values for the identifier are <code class="idl"><a data-link-type="idl" href="#trustedhtml" id="ref-for-trustedhtml⑥">TrustedHTML</a></code>, <code class="idl"><a data-link-type="idl" href="#trustedscript" id="ref-for-trustedscript②">TrustedScript</a></code>, <code class="idl"><a data-link-type="idl" href="#trustedscripturl" id="ref-for-trustedscripturl②">TrustedScriptURL</a></code> or <code class="idl"><a data-link-type="idl" href="#trustedurl" id="ref-for-trustedurl②">TrustedURL</a></code>.
+The only valid values for the identifier are <code class="idl"><a data-link-type="idl" href="#trustedhtml" id="ref-for-trustedhtml⑥">TrustedHTML</a></code>, <code class="idl"><a data-link-type="idl" href="#trustedscript" id="ref-for-trustedscript②">TrustedScript</a></code>, or <code class="idl"><a data-link-type="idl" href="#trustedscripturl" id="ref-for-trustedscripturl②">TrustedScriptURL</a></code>.
 This extended attribute must not appear on anything other than an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute③">attribute</a> or an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-operation" id="ref-for-dfn-operation">operation</a> argument.
 Additionally, it must not appear on <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-read-only" id="ref-for-dfn-read-only">read only</a> attributes.</p>
    <p>When the extended attribute appears on an attribute, the setter for that attribute must run the following steps in place of the ones specified in its description:</p>
@@ -2266,14 +2225,14 @@ Additionally, it must not appear on <a data-link-type="dfn" href="https://heycam
        <p>Set <var>sink</var> to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-concatenate" id="ref-for-string-concatenate">concatenating</a> the list « <var>objectName</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-attribute" id="ref-for-dfn-attribute④">attribute</a> identifier. » with <code>"."</code> as <var>separator</var>.</p>
        <div class="example" id="extended-attribute-attribute-example">
         <a class="self-link" href="#extended-attribute-attribute-example"></a> For example, the following annotation and JavaScript code: 
-<pre class="highlight"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <c- g>HTMLHyperlinkElementUtils</c-> {
-  [<c- g>CEReactions</c->, <c- g>TrustedTypes</c->=<c- n>TrustedURL</c->] <c- b>stringifier</c-> <c- b>attribute</c-> <c- n>URLString</c-> <c- g>href</c->;
+<pre class="highlight"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <c- g>HTMLScriptElement</c-> {
+  [<c- g>CEReactions</c->, <c- g>TrustedTypes</c->=<c- n>TrustedScriptURL</c->] <c- b>attribute</c-> <c- n>ScriptURLString</c-> <c- g>src</c->;
 };
 </pre>
-<pre class="highlight">document<c- p>.</c->createElement<c- p>(</c-><c- t>'a'</c-><c- p>).</c->href <c- o>=</c-> foo<c- p>;</c->
-document<c- p>.</c->createElement<c- p>(</c-><c- t>'a'</c-><c- p>).</c->setAttribute<c- p>(</c-><c- t>'HREF'</c-><c- p>,</c-> foo<c- p>);</c->
+<pre class="highlight">document<c- p>.</c->createElement<c- p>(</c-><c- t>'script'</c-><c- p>).</c->src <c- o>=</c-> foo<c- p>;</c->
+document<c- p>.</c->createElement<c- p>(</c-><c- t>'script'</c-><c- p>).</c->setAttribute<c- p>(</c-><c- t>'SrC'</c-><c- p>,</c-> foo<c- p>);</c->
 </pre>
-        <p>causes the <var>sink</var> value to be <code>"a.href"</code>.</p>
+        <p>causes the <var>sink</var> value to be <code>"script.src"</code>.</p>
        </div>
       <li data-md>
        <p>Set <var>value</var> to the result of running the <a data-link-type="abstract-op" href="#abstract-opdef-get-trusted-type-compliant-string" id="ref-for-abstract-opdef-get-trusted-type-compliant-string">Get Trusted Type compliant string</a> algorithm, passing the following arguments:</p>
@@ -2334,7 +2293,7 @@ document<c- p>.</c->createElement<c- p>(</c-><c- t>'a'</c-><c- p>).</c->setAttri
    </ol>
    <h2 class="heading settled" data-level="3" id="algorithms"><span class="secno">3. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
    <h3 class="heading settled" data-level="3.1" id="create-trusted-type-policy-algorithm"><span class="secno">3.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-create-a-trusted-type-policy">Create a Trusted Type Policy</dfn></span><a class="self-link" href="#create-trusted-type-policy-algorithm"></a></h3>
-   <p>To create a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy①⓪">TrustedTypePolicy</a></code>, given a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicyfactory" id="ref-for-trustedtypepolicyfactory">TrustedTypePolicyFactory</a></code> (<var>factory</var>),
+   <p>To create a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑨">TrustedTypePolicy</a></code>, given a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicyfactory" id="ref-for-trustedtypepolicyfactory">TrustedTypePolicyFactory</a></code> (<var>factory</var>),
 a string (<var>policyName</var>), <code class="idl"><a data-link-type="idl" href="#dictdef-trustedtypepolicyoptions" id="ref-for-dictdef-trustedtypepolicyoptions③">TrustedTypePolicyOptions</a></code> dictionary (<var>options</var>), and a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global">global object</a> (<var>global</var>) run these steps:</p>
    <ol>
     <li data-md>
@@ -2343,7 +2302,7 @@ creation be blocked by Content Security Policy?</a> algorithm with <var>global</
     <li data-md>
      <p>If <var>allowedByCSP</var> is <code>"Blocked"</code>, throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror">TypeError</a></code> and abort further steps.</p>
     <li data-md>
-     <p>Let <var>policy</var> be a new <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy①①">TrustedTypePolicy</a></code> object.</p>
+     <p>Let <var>policy</var> be a new <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy①⓪">TrustedTypePolicy</a></code> object.</p>
     <li data-md>
      <p>Set <var>policy</var>’s <code>name</code> property value to <var>policyName</var>.</p>
     <li data-md>
@@ -2354,8 +2313,6 @@ creation be blocked by Content Security Policy?</a> algorithm with <var>global</
      <p>Set <var>policyOptions</var> <code class="idl"><a data-link-type="idl" href="#dom-trustedtypepolicy-createscript" id="ref-for-dom-trustedtypepolicy-createscript①">createScript</a></code> property to <var>option</var>’s <code class="idl"><a data-link-type="idl" href="#dom-trustedtypepolicyoptions-createscript" id="ref-for-dom-trustedtypepolicyoptions-createscript">createScript</a></code> property value.</p>
     <li data-md>
      <p>Set <var>policyOptions</var> <code class="idl"><a data-link-type="idl" href="#dom-trustedtypepolicy-createscripturl" id="ref-for-dom-trustedtypepolicy-createscripturl①">createScriptURL</a></code> property to <var>option</var>’s <code class="idl"><a data-link-type="idl" href="#dom-trustedtypepolicyoptions-createscripturl" id="ref-for-dom-trustedtypepolicyoptions-createscripturl">createScriptURL</a></code> property value.</p>
-    <li data-md>
-     <p>Set <var>policyOptions</var> <code class="idl"><a data-link-type="idl" href="#dom-trustedtypepolicy-createurl" id="ref-for-dom-trustedtypepolicy-createurl①">createURL</a></code> property to <var>option</var>’s <code class="idl"><a data-link-type="idl" href="#dom-trustedtypepolicyoptions-createurl" id="ref-for-dom-trustedtypepolicyoptions-createurl">createURL</a></code> property value.</p>
     <li data-md>
      <p>Set <var>policy</var>’s <code>[[options]]</code> internal slot value to <em>policyOptions</em>.</p>
     <li data-md>
@@ -2373,7 +2330,7 @@ creation be blocked by Content Security Policy?</a> algorithm with <var>global</
 (null if the slot is empty).</p>
    </ol>
    <h3 class="heading settled" data-level="3.3" id="create-a-trusted-type-algorithm"><span class="secno">3.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-create-a-trusted-type">Create a Trusted Type</dfn></span><a class="self-link" href="#create-a-trusted-type-algorithm"></a></h3>
-   <p>Given a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy①②">TrustedTypePolicy</a></code> <var>policy</var>, a type name <var>trustedTypeName</var>,
+   <p>Given a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy①①">TrustedTypePolicy</a></code> <var>policy</var>, a type name <var>trustedTypeName</var>,
 a string <var>value</var> and a list <var>arguments</var>, execute the following steps:</p>
    <ol>
     <li data-md>
@@ -2393,9 +2350,6 @@ based on the following table:</p>
        <tr>
         <td>"createScriptURL"
         <td>"TrustedScriptURL"
-       <tr>
-        <td>"createURL"
-        <td>"TrustedURL"
      </table>
     <li data-md>
      <p>Let <var>options</var> be the value of <var>policy</var>’s <code>[[options]]</code> slot.</p>
@@ -2418,7 +2372,7 @@ set to <var>dataString</var>.</p>
      <p>Return <var>trustedObject</var>.</p>
    </ol>
    <h3 class="heading settled" data-level="3.4" id="get-trusted-type-compliant-string-algorithm"><span class="secno">3.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-get-trusted-type-compliant-string">Get Trusted Type compliant string</dfn></span><a class="self-link" href="#get-trusted-type-compliant-string-algorithm"></a></h3>
-   <p>This algorithm will return a string that can be assigned to a DOM <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①③">injection sink</a>, optionally unwrapping it from a matching <a data-link-type="dfn" href="#trusted-type" id="ref-for-trusted-type④">Trusted Type</a>.
+   <p>This algorithm will return a string that can be assigned to a DOM <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①②">injection sink</a>, optionally unwrapping it from a matching <a data-link-type="dfn" href="#trusted-type" id="ref-for-trusted-type④">Trusted Type</a>.
 It will ensure that the Trusted Type <a data-link-type="dfn" href="#enforcement" id="ref-for-enforcement④">enforcement</a> rules were respected.</p>
    <p>Given a <code class="idl"><a data-link-type="idl" href="#typedefdef-trustedtype" id="ref-for-typedefdef-trustedtype">TrustedType</a></code> type (<var>expectedType</var>), a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global①">global object</a> (<var>global</var>), <code class="idl"><a data-link-type="idl" href="#typedefdef-trustedtype" id="ref-for-typedefdef-trustedtype①">TrustedType</a></code> or a string (<var>input</var>), and a string (<var>sink</var>), run these steps:</p>
    <ol>
@@ -2440,7 +2394,7 @@ return stringified <var>input</var> and abort these steps.</p>
       <li data-md>
        <p>If <var>defaultPolicy</var> is <code>null</code>, abort these steps and resume below.</p>
       <li data-md>
-       <p>Let <var>convertedInput</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-trusted-type" id="ref-for-abstract-opdef-create-a-trusted-type④">Create a
+       <p>Let <var>convertedInput</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-trusted-type" id="ref-for-abstract-opdef-create-a-trusted-type③">Create a
 Trusted Type</a> algorithm, with the following arguments:</p>
        <ul>
         <li data-md>
@@ -2469,13 +2423,12 @@ passing <var>global</var>, <var>input</var> as <var>source</var>, and <var>sink<
      <p>Throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror②">TypeError</a></code>.</p>
    </ol>
    <h2 class="heading settled" data-level="4" id="integrations"><span class="secno">4. </span><span class="content">Integrations</span><a class="self-link" href="#integrations"></a></h2>
-<pre class="idl highlight def"><c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②②"><c- b>DOMString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑦"><c- n>TrustedHTML</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-htmlstring"><code><c- g>HTMLString</c-></code></dfn>;
-<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②③"><c- b>DOMString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript③"><c- n>TrustedScript</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-scriptstring"><code><c- g>ScriptString</c-></code></dfn>;
-<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②"><c- b>USVString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl③"><c- n>TrustedScriptURL</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-scripturlstring"><code><c- g>ScriptURLString</c-></code></dfn>;
-<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③"><c- b>USVString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl③"><c- n>TrustedURL</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-urlstring"><code><c- g>URLString</c-></code></dfn>;
-<c- b>typedef</c-> (<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑧"><c- n>TrustedHTML</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript④"><c- n>TrustedScript</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl④"><c- n>TrustedScriptURL</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl④"><c- n>TrustedURL</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-trustedtype"><code><c- g>TrustedType</c-></code></dfn>;
+<pre class="idl highlight def"><c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⓪"><c- b>DOMString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑦"><c- n>TrustedHTML</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-htmlstring"><code><c- g>HTMLString</c-></code></dfn>;
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript③"><c- n>TrustedScript</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-scriptstring"><code><c- g>ScriptString</c-></code></dfn>;
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl③"><c- n>TrustedScriptURL</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-scripturlstring"><code><c- g>ScriptURLString</c-></code></dfn>;
+<c- b>typedef</c-> (<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑧"><c- n>TrustedHTML</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript④"><c- n>TrustedScript</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl④"><c- n>TrustedScriptURL</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-trustedtype"><code><c- g>TrustedType</c-></code></dfn>;
 
-<c- b>typedef</c-> (([<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②④"><c- b>DOMString</c-></a>) <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑨"><c- n>TrustedHTML</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-htmlstringdefaultsempty"><code><c- g>HTMLStringDefaultsEmpty</c-></code></dfn>;
+<c- b>typedef</c-> (([<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②②"><c- b>DOMString</c-></a>) <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑨"><c- n>TrustedHTML</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-htmlstringdefaultsempty"><code><c- g>HTMLStringDefaultsEmpty</c-></code></dfn>;
 </pre>
    <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#typedefdef-htmlstringdefaultsempty" id="ref-for-typedefdef-htmlstringdefaultsempty">HTMLStringDefaultsEmpty</a></code> is a non-nullable variant that accepts <em>null</em> on set.
 Having this separate type allows <a href="https://heycam.github.io/webidl/#TreatNullAs">Web IDL §3.3.21 [TreatNullAs]</a> to attach to DOMString
@@ -2491,13 +2444,8 @@ which is a <code class="idl"><a data-link-type="idl" href="#trustedtypepolicyfac
    <h4 class="heading settled" data-level="4.1.1" id="extensions-to-the-window-interface"><span class="secno">4.1.1. </span><span class="content">Extensions to the Window interface</span><a class="self-link" href="#extensions-to-the-window-interface"></a></h4>
    <p>This document extends the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window②">Window</a></code> interface defined by <a data-link-type="biblio" href="#biblio-html5">HTML</a>:</p>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window③"><c- g>Window</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①②"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c->
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①⓪"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c->
       <a class="n" data-link-type="idl-name" href="#trustedtypepolicyfactory" id="ref-for-trustedtypepolicyfactory③"><c- n>TrustedTypePolicyFactory</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Window" data-dfn-type="attribute" data-export data-readonly data-type="TrustedTypePolicyFactory" id="dom-window-trustedtypes"><code><c- g>trustedTypes</c-></code></dfn>;
-
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy"><c- n>WindowProxy</c-></a>? <dfn class="idl-code" data-dfn-for="Window" data-dfn-type="method" data-export data-lt="open(url, target, features)|open(url, target)|open(url)|open()" id="dom-window-open"><code><c- g>open</c-></code><a class="self-link" href="#dom-window-open"></a></dfn>(
-      [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑦"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑤"><c- n>TrustedURL</c-></a>] <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="Window/open(url, target, features), Window/open(url, target), Window/open(url), Window/open()" data-dfn-type="argument" data-export id="dom-window-open-url-target-features-url"><code><c- g>url</c-></code><a class="self-link" href="#dom-window-open-url-target-features-url"></a></dfn> = "about:blank",
-      <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑤"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Window/open(url, target, features), Window/open(url, target), Window/open(url), Window/open()" data-dfn-type="argument" data-export id="dom-window-open-url-target-features-target"><code><c- g>target</c-></code><a class="self-link" href="#dom-window-open-url-target-features-target"></a></dfn> = "_blank",
-      <c- b>optional</c-> ([<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs①"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑥"><c- b>DOMString</c-></a>) <dfn class="idl-code" data-dfn-for="Window/open(url, target, features), Window/open(url, target), Window/open(url), Window/open()" data-dfn-type="argument" data-export id="dom-window-open-url-target-features-features"><code><c- g>features</c-></code><a class="self-link" href="#dom-window-open-url-target-features-features"></a></dfn> = "");
 };
 </pre>
    <p><code class="idl"><a data-link-type="idl" href="#dom-window-trustedtypes" id="ref-for-dom-window-trustedtypes①">trustedTypes</a></code> returns the <a href="#integration-with-html">trusted
@@ -2508,75 +2456,40 @@ type policy factory</a> of the current <code class="idl"><a data-link-type="idl"
    <h4 class="heading settled" data-level="4.1.2" id="extensions-to-the-document-interface"><span class="secno">4.1.2. </span><span class="content">Extensions to the Document interface</span><a class="self-link" href="#extensions-to-the-document-interface"></a></h4>
    <p>This document modifies the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> interface defined by <a data-link-type="biblio" href="#biblio-html5">HTML</a>:</p>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②"><c- g>Document</c-></a> {
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy①"><c- n>WindowProxy</c-></a>? <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="open(url, name, features)" id="dom-document-open"><code><c- g>open</c-></code><a class="self-link" href="#dom-document-open"></a></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑧"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑥"><c- n>TrustedURL</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="Document/open(url, name, features)" data-dfn-type="argument" data-export id="dom-document-open-url-name-features-url"><code><c- g>url</c-></code><a class="self-link" href="#dom-document-open-url-name-features-url"></a></dfn>, <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑦"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Document/open(url, name, features)" data-dfn-type="argument" data-export id="dom-document-open-url-name-features-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-document-open-url-name-features-name"></a></dfn>, <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑧"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Document/open(url, name, features)" data-dfn-type="argument" data-export id="dom-document-open-url-name-features-features"><code><c- g>features</c-></code><a class="self-link" href="#dom-document-open-url-name-features-features"></a></dfn>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions"><c- g>CEReactions</c-></a>] <c- b>void</c-> <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="write(...text)|write()" id="dom-document-write"><code><c- g>write</c-></code><a class="self-link" href="#dom-document-write"></a></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑨"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⓪"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring"><c- n>HTMLString</c-></a>... <dfn class="idl-code" data-dfn-for="Document/write(...text)" data-dfn-type="argument" data-export id="dom-document-write-text-text"><code><c- g>text</c-></code><a class="self-link" href="#dom-document-write-text-text"></a></dfn>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①"><c- g>CEReactions</c-></a>] <c- b>void</c-> <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="writeln(...text)|writeln()" id="dom-document-writeln"><code><c- g>writeln</c-></code><a class="self-link" href="#dom-document-writeln"></a></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⓪"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring①"><c- n>HTMLString</c-></a>... <dfn class="idl-code" data-dfn-for="Document/writeln(...text)" data-dfn-type="argument" data-export id="dom-document-writeln-text-text"><code><c- g>text</c-></code><a class="self-link" href="#dom-document-writeln-text-text"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions"><c- g>CEReactions</c-></a>] <c- b>void</c-> <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="write(...text)|write()" id="dom-document-write"><code><c- g>write</c-></code><a class="self-link" href="#dom-document-write"></a></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑦"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⓪"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring"><c- n>HTMLString</c-></a>... <dfn class="idl-code" data-dfn-for="Document/write(...text)" data-dfn-type="argument" data-export id="dom-document-write-text-text"><code><c- g>text</c-></code><a class="self-link" href="#dom-document-write-text-text"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①"><c- g>CEReactions</c-></a>] <c- b>void</c-> <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="writeln(...text)|writeln()" id="dom-document-writeln"><code><c- g>writeln</c-></code><a class="self-link" href="#dom-document-writeln"></a></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑧"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring①"><c- n>HTMLString</c-></a>... <dfn class="idl-code" data-dfn-for="Document/writeln(...text)" data-dfn-type="argument" data-export id="dom-document-writeln-text-text"><code><c- g>text</c-></code><a class="self-link" href="#dom-document-writeln-text-text"></a></dfn>);
 };
 </pre>
-   <p class="note" role="note"><span>Note:</span> This document does not affect the two argument form of <a href="https://html.spec.whatwg.org/multipage//dynamic-markup-insertion#dom-document-open">document.open</a>.</p>
-   <h4 class="heading settled" data-level="4.1.3" id="extensions-to-the-location-interface"><span class="secno">4.1.3. </span><span class="content">Extensions to the Location interface</span><a class="self-link" href="#extensions-to-the-location-interface"></a></h4>
-   <p>This document modifies the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/history.html#location" id="ref-for-location">Location</a></code> interface defined by <a data-link-type="biblio" href="#biblio-html5">HTML</a>:</p>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/history.html#location" id="ref-for-location①"><c- g>Location</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①③"><c- g>Unforgeable</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑦"><c- n>TrustedURL</c-></a>] <dfn data-dfn-for="Location" data-dfn-type="dfn" data-export data-lt="stringification behavior" id="Location-stringification-behavior"><c- b>stringifier</c-><a class="self-link" href="#Location-stringification-behavior"></a></dfn> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring②"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="attribute" data-export data-type="URLString" id="dom-location-href"><code><c- g>href</c-></code><a class="self-link" href="#dom-location-href"></a></dfn>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①④"><c- g>Unforgeable</c-></a>] <c- b>void</c-> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="method" data-export data-lt="assign(url)" id="dom-location-assign"><code><c- g>assign</c-></code><a class="self-link" href="#dom-location-assign"></a></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①②"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑧"><c- n>TrustedURL</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring③"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="Location/assign(url)" data-dfn-type="argument" data-export id="dom-location-assign-url-url"><code><c- g>url</c-></code><a class="self-link" href="#dom-location-assign-url-url"></a></dfn>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①⑤"><c- g>Unforgeable</c-></a>] <c- b>void</c-> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="method" data-export data-lt="replace(url)" id="dom-location-replace"><code><c- g>replace</c-></code><a class="self-link" href="#dom-location-replace"></a></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①③"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑨"><c- n>TrustedURL</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring④"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="Location/replace(url)" data-dfn-type="argument" data-export id="dom-location-replace-url-url"><code><c- g>url</c-></code><a class="self-link" href="#dom-location-replace-url-url"></a></dfn>);
-};
-</pre>
-   <h4 class="heading settled" data-level="4.1.4" id="enforcement-in-sinks"><span class="secno">4.1.4. </span><span class="content">Enforcement in element attributes</span><a class="self-link" href="#enforcement-in-sinks"></a></h4>
+   <h4 class="heading settled" data-level="4.1.3" id="enforcement-in-sinks"><span class="secno">4.1.3. </span><span class="content">Enforcement in element attributes</span><a class="self-link" href="#enforcement-in-sinks"></a></h4>
    <p>This document modifies following IDL attributes of various DOM elements:</p>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement"><c- g>HTMLScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①④"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑤"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring"><c- n>ScriptURLString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="HTMLScriptElement" data-dfn-type="attribute" data-export data-type="ScriptURLString" id="dom-htmlscriptelement-src"><code><c- g>src</c-></code></dfn>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions③"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑤"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑤"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring"><c- n>ScriptString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="HTMLScriptElement" data-dfn-type="attribute" data-export data-type="ScriptString" id="dom-htmlscriptelement-text"><code><c- g>text</c-></code></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑨"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑤"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring"><c- n>ScriptURLString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="HTMLScriptElement" data-dfn-type="attribute" data-export data-type="ScriptURLString" id="dom-htmlscriptelement-src"><code><c- g>src</c-></code></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions③"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⓪"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑤"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring"><c- n>ScriptString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="HTMLScriptElement" data-dfn-type="attribute" data-export data-type="ScriptString" id="dom-htmlscriptelement-text"><code><c- g>text</c-></code></dfn>;
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement" id="ref-for-htmliframeelement"><c- g>HTMLIFrameElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement①"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions④"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑥"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⓪"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑤"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLIFrameElement" data-dfn-type="attribute" data-export data-type="URLString" id="dom-htmliframeelement-src"><code><c- g>src</c-></code><a class="self-link" href="#dom-htmliframeelement-src"></a></dfn>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑤"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑦"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①②"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring②"><c- n>HTMLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLIFrameElement" data-dfn-type="attribute" data-export data-type="HTMLString" id="dom-htmliframeelement-srcdoc"><code><c- g>srcdoc</c-></code><a class="self-link" href="#dom-htmliframeelement-srcdoc"></a></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions④"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①②"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring②"><c- n>HTMLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLIFrameElement" data-dfn-type="attribute" data-export data-type="HTMLString" id="dom-htmliframeelement-srcdoc"><code><c- g>srcdoc</c-></code><a class="self-link" href="#dom-htmliframeelement-srcdoc"></a></dfn>;
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement" id="ref-for-htmlembedelement"><c- g>HTMLEmbedElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement②"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑥"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑧"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑥"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring①"><c- n>ScriptURLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLEmbedElement" data-dfn-type="attribute" data-export data-type="ScriptURLString" id="dom-htmlembedelement-src"><code><c- g>src</c-></code><a class="self-link" href="#dom-htmlembedelement-src"></a></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑤"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①②"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑥"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring①"><c- n>ScriptURLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLEmbedElement" data-dfn-type="attribute" data-export data-type="ScriptURLString" id="dom-htmlembedelement-src"><code><c- g>src</c-></code><a class="self-link" href="#dom-htmlembedelement-src"></a></dfn>;
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement" id="ref-for-htmlobjectelement"><c- g>HTMLObjectElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement③"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑦"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑨"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑦"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring②"><c- n>ScriptURLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLObjectElement" data-dfn-type="attribute" data-export data-type="ScriptURLString" id="dom-htmlobjectelement-data"><code><c- g>data</c-></code><a class="self-link" href="#dom-htmlobjectelement-data"></a></dfn>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑧"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⓪"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑧"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑨"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLObjectElement" data-dfn-type="attribute" data-export data-type="DOMString" id="dom-htmlobjectelement-codebase"><code><c- g>codeBase</c-></code><a class="self-link" href="#dom-htmlobjectelement-codebase"></a></dfn>; // obsolete
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/obsolete.html#htmlframeelement" id="ref-for-htmlframeelement"><c- g>HTMLFrameElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement④"><c- n>HTMLElement</c-></a> { // obsolete
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑨"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①①"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑥"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLFrameElement" data-dfn-type="attribute" data-export data-type="URLString" id="dom-htmlframeelement-src"><code><c- g>src</c-></code><a class="self-link" href="#dom-htmlframeelement-src"></a></dfn>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement"><c- g>HTMLFormElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑤"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⓪"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②②"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①②"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑦"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLFormElement" data-dfn-type="attribute" data-export data-type="URLString" id="dom-htmlformelement-action"><code><c- g>action</c-></code><a class="self-link" href="#dom-htmlformelement-action"></a></dfn>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement" id="ref-for-htmlinputelement"><c- g>HTMLInputElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑥"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②③"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①③"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑧"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLInputElement" data-dfn-type="attribute" data-export data-type="URLString" id="dom-htmlinputelement-formaction"><code><c- g>formAction</c-></code><a class="self-link" href="#dom-htmlinputelement-formaction"></a></dfn>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①②"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②④"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①④"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑨"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLInputElement" data-dfn-type="attribute" data-export data-type="URLString" id="dom-htmlinputelement-src"><code><c- g>src</c-></code><a class="self-link" href="#dom-htmlinputelement-src"></a></dfn>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement" id="ref-for-htmlbuttonelement"><c- g>HTMLButtonElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑦"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①③"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⑤"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑤"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①⓪"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLButtonElement" data-dfn-type="attribute" data-export data-type="URLString" id="dom-htmlbuttonelement-formaction"><code><c- g>formAction</c-></code><a class="self-link" href="#dom-htmlbuttonelement-formaction"></a></dfn>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils" id="ref-for-htmlhyperlinkelementutils"><c- g>HTMLHyperlinkElementUtils</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①④"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⑥"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑥"><c- n>TrustedURL</c-></a>] <dfn data-dfn-for="HTMLHyperlinkElementUtils" data-dfn-type="dfn" data-export data-lt="stringification behavior" id="HTMLHyperlinkElementUtils-stringification-behavior"><c- b>stringifier</c-><a class="self-link" href="#HTMLHyperlinkElementUtils-stringification-behavior"></a></dfn> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①①"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLHyperlinkElementUtils" data-dfn-type="attribute" data-export data-type="URLString" id="dom-htmlhyperlinkelementutils-href"><code><c- g>href</c-></code><a class="self-link" href="#dom-htmlhyperlinkelementutils-href"></a></dfn>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmlbaseelement" id="ref-for-htmlbaseelement"><c- g>HTMLBaseElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑧"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑤"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⑦"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑦"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①②"><c- n>URLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLBaseElement" data-dfn-type="attribute" data-export data-type="URLString" id="dom-htmlbaseelement-href"><code><c- g>href</c-></code><a class="self-link" href="#dom-htmlbaseelement-href"></a></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑥"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①③"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑦"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring②"><c- n>ScriptURLString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLObjectElement" data-dfn-type="attribute" data-export data-type="ScriptURLString" id="dom-htmlobjectelement-data"><code><c- g>data</c-></code><a class="self-link" href="#dom-htmlobjectelement-data"></a></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑦"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①④"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑧"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②③"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLObjectElement" data-dfn-type="attribute" data-export data-type="DOMString" id="dom-htmlobjectelement-codebase"><code><c- g>codeBase</c-></code><a class="self-link" href="#dom-htmlobjectelement-codebase"></a></dfn>; // obsolete
 };
 
 // TODO: Add HTMLPortalElement.src from https://github.com/WICG/portals once it’s specced.
 </pre>
-   <h4 class="heading settled" data-level="4.1.5" id="enforcement-in-script-text"><span class="secno">4.1.5. </span><span class="content">Enforcement for script text contents</span><a class="self-link" href="#enforcement-in-script-text"></a></h4>
+   <p class="issue" id="issue-13577559"><a class="self-link" href="#issue-13577559"></a> Add base.href enforcement.</p>
+   <h4 class="heading settled" data-level="4.1.4" id="enforcement-in-script-text"><span class="secno">4.1.4. </span><span class="content">Enforcement for script text contents</span><a class="self-link" href="#enforcement-in-script-text"></a></h4>
    <p>This document modifies how <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement①">HTMLScriptElement</a></code> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-child-text-content" id="ref-for-concept-child-text-content">child text content</a> can be set to allow applications to control dynamically created scripts. It does so by
 adding the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#dom-innertext" id="ref-for-dom-innertext">innerText</a></code> and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-textcontent" id="ref-for-dom-node-textcontent">textContent</a></code> attributes directly on <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement②">HTMLScriptElement</a></code>. The behavior of the attributes remains the same
-as in their original counterparts, apart from additional behavior triggered by the <code class="idl"><a data-link-type="idl" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⑧">TrustedTypes</a></code> extended attribute presence.</p>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement③"><c- g>HTMLScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑨"><c- n>HTMLElement</c-></a> {
- [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑥"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⑨"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑥"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs②"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring①"><c- n>ScriptString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLScriptElement" data-dfn-type="attribute" data-export data-type="[TreatNullAs=EmptyString] ScriptString" id="dom-htmlscriptelement-innertext"><code><c- g>innerText</c-></code><a class="self-link" href="#dom-htmlscriptelement-innertext"></a></dfn>;
- [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑦"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③⓪"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑦"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring②"><c- n>ScriptString</c-></a>? <dfn class="idl-code" data-dfn-for="HTMLScriptElement" data-dfn-type="attribute" data-export data-type="ScriptString?" id="dom-htmlscriptelement-textcontent"><code><c- g>textContent</c-></code><a class="self-link" href="#dom-htmlscriptelement-textcontent"></a></dfn>;
+as in their original counterparts, apart from additional behavior triggered by the <code class="idl"><a data-link-type="idl" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑤">TrustedTypes</a></code> extended attribute presence.</p>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement③"><c- g>HTMLScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement④"><c- n>HTMLElement</c-></a> {
+ [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑧"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑥"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑥"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs①"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring①"><c- n>ScriptString</c-></a> <dfn class="idl-code" data-dfn-for="HTMLScriptElement" data-dfn-type="attribute" data-export data-type="[TreatNullAs=EmptyString] ScriptString" id="dom-htmlscriptelement-innertext"><code><c- g>innerText</c-></code><a class="self-link" href="#dom-htmlscriptelement-innertext"></a></dfn>;
+ [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑨"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑦"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑦"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring②"><c- n>ScriptString</c-></a>? <dfn class="idl-code" data-dfn-for="HTMLScriptElement" data-dfn-type="attribute" data-export data-type="ScriptString?" id="dom-htmlscriptelement-textcontent"><code><c- g>textContent</c-></code><a class="self-link" href="#dom-htmlscriptelement-textcontent"></a></dfn>;
 };
 </pre>
    <p>Additionally, this document defines <a data-link-type="abstract-op" href="#abstract-opdef-insert-text-node-validation-steps" id="ref-for-abstract-opdef-insert-text-node-validation-steps">insert text node validation steps</a> for <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement④">HTMLScriptElement</a></code> to ascertain that text nodes inserted under <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement⑤">HTMLScriptElement</a></code> elements will satisfy Trusted Types restrictions:</p>
@@ -2604,7 +2517,7 @@ s<c- p>.</c->appendChild<c- p>(</c->text<c- p>);</c-> <c- c1>// TypeError</c->
 p<c- p>.</c->insertAdjacentText<c- p>(</c-><c- t>'beforebegin'</c-><c- p>,</c-> <c- t>'alert(2)'</c-><c- p>);</c-> <c- c1>// TypeError</c->
 </pre>
    </div>
-   <h4 class="heading settled" data-level="4.1.6" id="enforcement-in-timer-functions"><span class="secno">4.1.6. </span><span class="content">Enforcement in timer functions</span><a class="self-link" href="#enforcement-in-timer-functions"></a></h4>
+   <h4 class="heading settled" data-level="4.1.5" id="enforcement-in-timer-functions"><span class="secno">4.1.5. </span><span class="content">Enforcement in timer functions</span><a class="self-link" href="#enforcement-in-timer-functions"></a></h4>
    <p>This document modifies the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope" id="ref-for-windoworworkerglobalscope">WindowOrWorkerGlobalScope</a></code> interface mixin:</p>
 <pre class="idl highlight def"><c- b>typedef</c-> (<a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring③"><c- n>ScriptString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#Function" id="ref-for-Function"><c- n>Function</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-trustedtimerhandler"><code><c- g>TrustedTimerHandler</c-></code></dfn>;
 
@@ -2634,7 +2547,7 @@ the <a data-link-type="abstract-op" href="#abstract-opdef-get-trusted-type-compl
    <p class="note" role="note"><span>Note:</span> This makes sure that a <code class="idl"><a data-link-type="idl" href="#trustedscript" id="ref-for-trustedscript①⓪">TrustedScript</a></code> is passed to timer
 functions in place of a string when Trusted Types are enforced, but
 also unconditionally accepts any <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#Function" id="ref-for-Function②">Function</a></code> object.</p>
-   <h4 class="heading settled" data-level="4.1.7" id="enforcement-in-event-handler-content-attributes"><span class="secno">4.1.7. </span><span class="content">Enforcement in event handler content attributes</span><a class="self-link" href="#enforcement-in-event-handler-content-attributes"></a></h4>
+   <h4 class="heading settled" data-level="4.1.6" id="enforcement-in-event-handler-content-attributes"><span class="secno">4.1.6. </span><span class="content">Enforcement in event handler content attributes</span><a class="self-link" href="#enforcement-in-event-handler-content-attributes"></a></h4>
    <p>This document modifies the <a href="https://www.w3.org/TR/html5/#event-handler-content-attributes">attribute change steps for an event handler content attribute</a>.</p>
    <p>At the beginning of step 5, insert the following steps:</p>
    <ol>
@@ -2664,14 +2577,10 @@ img<c- p>.</c->setAttribute<c- p>(</c-><c- t>'onerror'</c-><c- p>,</c-> <c- t>'a
 </pre>
    </div>
    <h3 class="heading settled" data-level="4.2" id="integration-with-svg"><span class="secno">4.2. </span><span class="content">Integration with SVG</span><a class="self-link" href="#integration-with-svg"></a></h3>
-   <p>This document modifies the <code class="idl"><a data-link-type="idl" href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement" id="ref-for-InterfaceSVGScriptElement">SVGScriptElement</a></code> interface and <code class="idl"><a data-link-type="idl" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGURIReference" id="ref-for-InterfaceSVGURIReference">SVGURIReference</a></code> interfaces to enforce Trusted Types on those:</p>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGURIReference" id="ref-for-InterfaceSVGURIReference①"><c- g>SVGURIReference</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject" id="ref-for-SameObject"><c- g>SameObject</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑧"><c- n>TrustedURL</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString" id="ref-for-InterfaceSVGAnimatedString"><c- n>SVGAnimatedString</c-></a> <dfn class="idl-code" data-dfn-for="SVGURIReference" data-dfn-type="attribute" data-export data-readonly data-type="SVGAnimatedString" id="dom-svgurireference-href"><code><c- g>href</c-></code><a class="self-link" href="#dom-svgurireference-href"></a></dfn>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement" id="ref-for-InterfaceSVGScriptElement①"><c- g>SVGScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement" id="ref-for-InterfaceSVGElement"><c- n>SVGElement</c-></a> {
+   <p>This document modifies the <code class="idl"><a data-link-type="idl" href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement" id="ref-for-InterfaceSVGScriptElement">SVGScriptElement</a></code> interface to enforce Trusted Types:</p>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement" id="ref-for-InterfaceSVGScriptElement①"><c- g>SVGScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement" id="ref-for-InterfaceSVGElement"><c- n>SVGElement</c-></a> {
  // overwrites the definition in SVGURIReference.
- [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③②"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑨"><c- n>TrustedScriptURL</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring③"><c- n>ScriptURLString</c-></a> <dfn class="idl-code" data-dfn-for="SVGScriptElement" data-dfn-type="attribute" data-export data-readonly data-type="ScriptURLString" id="dom-svgscriptelement-href"><code><c- g>href</c-></code><a class="self-link" href="#dom-svgscriptelement-href"></a></dfn>;
+ [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑧"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑨"><c- n>TrustedScriptURL</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring③"><c- n>ScriptURLString</c-></a> <dfn class="idl-code" data-dfn-for="SVGScriptElement" data-dfn-type="attribute" data-export data-readonly data-type="ScriptURLString" id="dom-svgscriptelement-href"><code><c- g>href</c-></code><a class="self-link" href="#dom-svgscriptelement-href"></a></dfn>;
 };
 </pre>
    <p>Additionally, this document defines <a data-link-type="abstract-op" href="#abstract-opdef-insert-text-node-validation-steps" id="ref-for-abstract-opdef-insert-text-node-validation-steps①">insert text node validation steps</a> for <code class="idl"><a data-link-type="idl" href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement" id="ref-for-InterfaceSVGScriptElement②">SVGScriptElement</a></code> to ascertain that text nodes inserted to <code class="idl"><a data-link-type="idl" href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement" id="ref-for-InterfaceSVGScriptElement③">SVGScriptElement</a></code> elements will satisfy Trusted Types restrictions:</p>
@@ -2696,30 +2605,30 @@ If the algorithm threw an error, rethrow the error.</p>
    <h3 class="heading settled" data-level="4.4" id="integration-with-dom-parsing"><span class="secno">4.4. </span><span class="content">Integration with DOM Parsing</span><a class="self-link" href="#integration-with-dom-parsing"></a></h3>
    <p>This document modifies the following interfaces defined by <a data-link-type="biblio" href="#biblio-dom-parsing">[DOM-Parsing]</a>:</p>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②"><c- g>Element</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑧"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③③"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①③"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstringdefaultsempty" id="ref-for-typedefdef-htmlstringdefaultsempty①"><c- n>HTMLStringDefaultsEmpty</c-></a> <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="attribute" data-export data-type="HTMLStringDefaultsEmpty" id="dom-element-outerhtml"><code><c- g>outerHTML</c-></code><a class="self-link" href="#dom-element-outerhtml"></a></dfn>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑨"><c- g>CEReactions</c-></a>] <c- b>void</c-> <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export data-lt="insertAdjacentHTML(position, text)" id="dom-element-insertadjacenthtml"><code><c- g>insertAdjacentHTML</c-></code><a class="self-link" href="#dom-element-insertadjacenthtml"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③⓪"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Element/insertAdjacentHTML(position, text)" data-dfn-type="argument" data-export id="dom-element-insertadjacenthtml-position-text-position"><code><c- g>position</c-></code><a class="self-link" href="#dom-element-insertadjacenthtml-position-text-position"></a></dfn>, [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③④"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①④"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring③"><c- n>HTMLString</c-></a> <dfn class="idl-code" data-dfn-for="Element/insertAdjacentHTML(position, text)" data-dfn-type="argument" data-export id="dom-element-insertadjacenthtml-position-text-text"><code><c- g>text</c-></code><a class="self-link" href="#dom-element-insertadjacenthtml-position-text-text"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⓪"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑨"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①③"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstringdefaultsempty" id="ref-for-typedefdef-htmlstringdefaultsempty①"><c- n>HTMLStringDefaultsEmpty</c-></a> <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="attribute" data-export data-type="HTMLStringDefaultsEmpty" id="dom-element-outerhtml"><code><c- g>outerHTML</c-></code><a class="self-link" href="#dom-element-outerhtml"></a></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①①"><c- g>CEReactions</c-></a>] <c- b>void</c-> <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export data-lt="insertAdjacentHTML(position, text)" id="dom-element-insertadjacenthtml"><code><c- g>insertAdjacentHTML</c-></code><a class="self-link" href="#dom-element-insertadjacenthtml"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Element/insertAdjacentHTML(position, text)" data-dfn-type="argument" data-export id="dom-element-insertadjacenthtml-position-text-position"><code><c- g>position</c-></code><a class="self-link" href="#dom-element-insertadjacenthtml-position-text-position"></a></dfn>, [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⓪"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①④"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring③"><c- n>HTMLString</c-></a> <dfn class="idl-code" data-dfn-for="Element/insertAdjacentHTML(position, text)" data-dfn-type="argument" data-export id="dom-element-insertadjacenthtml-position-text-text"><code><c- g>text</c-></code><a class="self-link" href="#dom-element-insertadjacenthtml-position-text-text"></a></dfn>);
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface"><c- g>InnerHTML</c-></a> { // specified in a draft version at https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②⓪"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③⑤"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑤"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstringdefaultsempty" id="ref-for-typedefdef-htmlstringdefaultsempty②"><c- n>HTMLStringDefaultsEmpty</c-></a> <dfn class="idl-code" data-dfn-for="InnerHTML" data-dfn-type="attribute" data-export data-type="HTMLStringDefaultsEmpty" id="dom-innerhtml-innerhtml"><code><c- g>innerHTML</c-></code><a class="self-link" href="#dom-innerhtml-innerhtml"></a></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①②"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑤"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstringdefaultsempty" id="ref-for-typedefdef-htmlstringdefaultsempty②"><c- n>HTMLStringDefaultsEmpty</c-></a> <dfn class="idl-code" data-dfn-for="InnerHTML" data-dfn-type="attribute" data-export data-type="HTMLStringDefaultsEmpty" id="dom-innerhtml-innerhtml"><code><c- g>innerHTML</c-></code><a class="self-link" href="#dom-innerhtml-innerhtml"></a></dfn>;
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#range" id="ref-for-range"><c- g>Range</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment"><c- n>DocumentFragment</c-></a> <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export data-lt="createContextualFragment(fragment)" id="dom-range-createcontextualfragment"><code><c- g>createContextualFragment</c-></code><a class="self-link" href="#dom-range-createcontextualfragment"></a></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③⑥"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑥"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring④"><c- n>HTMLString</c-></a> <dfn class="idl-code" data-dfn-for="Range/createContextualFragment(fragment)" data-dfn-type="argument" data-export id="dom-range-createcontextualfragment-fragment-fragment"><code><c- g>fragment</c-></code><a class="self-link" href="#dom-range-createcontextualfragment-fragment-fragment"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①③"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment"><c- n>DocumentFragment</c-></a> <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export data-lt="createContextualFragment(fragment)" id="dom-range-createcontextualfragment"><code><c- g>createContextualFragment</c-></code><a class="self-link" href="#dom-range-createcontextualfragment"></a></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②②"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑥"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring④"><c- n>HTMLString</c-></a> <dfn class="idl-code" data-dfn-for="Range/createContextualFragment(fragment)" data-dfn-type="argument" data-export id="dom-range-createcontextualfragment-fragment-fragment"><code><c- g>fragment</c-></code><a class="self-link" href="#dom-range-createcontextualfragment-fragment-fragment"></a></dfn>);
 };
 
-[<dfn class="idl-code" data-dfn-for="DOMParser" data-dfn-type="constructor" data-export data-lt="DOMParser()" id="dom-domparser-domparser"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-domparser-domparser"></a></dfn>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+[<dfn class="idl-code" data-dfn-for="DOMParser" data-dfn-type="constructor" data-export data-lt="DOMParser()" id="dom-domparser-domparser"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-domparser-domparser"></a></dfn>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <dfn class="idl-code" data-dfn-type="interface" data-export id="domparser"><code><c- g>DOMParser</c-></code><a class="self-link" href="#domparser"></a></dfn> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③"><c- n>Document</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMParser" data-dfn-type="method" data-export data-lt="parseFromString(str, type)" id="dom-domparser-parsefromstring"><code><c- g>parseFromString</c-></code></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③⑦"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑦"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring⑤"><c- n>HTMLString</c-></a> <dfn class="idl-code" data-dfn-for="DOMParser/parseFromString(str, type)" data-dfn-type="argument" data-export id="dom-domparser-parsefromstring-str-type-str"><code><c- g>str</c-></code><a class="self-link" href="#dom-domparser-parsefromstring-str-type-str"></a></dfn>, <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/DOM-Parsing/#h-the-domparser-interface" id="ref-for-h-the-domparser-interface"><c- n>SupportedType</c-></a> <dfn class="idl-code" data-dfn-for="DOMParser/parseFromString(str, type)" data-dfn-type="argument" data-export id="dom-domparser-parsefromstring-str-type-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-domparser-parsefromstring-str-type-type"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③"><c- n>Document</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="DOMParser" data-dfn-type="method" data-export data-lt="parseFromString(str, type)" id="dom-domparser-parsefromstring"><code><c- g>parseFromString</c-></code></dfn>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②③"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑦"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring⑤"><c- n>HTMLString</c-></a> <dfn class="idl-code" data-dfn-for="DOMParser/parseFromString(str, type)" data-dfn-type="argument" data-export id="dom-domparser-parsefromstring-str-type-str"><code><c- g>str</c-></code><a class="self-link" href="#dom-domparser-parsefromstring-str-type-str"></a></dfn>, <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/DOM-Parsing/#h-the-domparser-interface" id="ref-for-h-the-domparser-interface"><c- n>SupportedType</c-></a> <dfn class="idl-code" data-dfn-for="DOMParser/parseFromString(str, type)" data-dfn-type="argument" data-export id="dom-domparser-parsefromstring-str-type-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-domparser-parsefromstring-str-type-type"></a></dfn>);
 };
 </pre>
    <h3 class="heading settled" data-level="4.5" id="integration-with-content-security-policy"><span class="secno">4.5. </span><span class="content">Integration with Content Security Policy</span><a class="self-link" href="#integration-with-content-security-policy"></a></h3>
    <h4 class="heading settled" data-level="4.5.1" id="trusted-types-csp-directive"><span class="secno">4.5.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="trusted-types-directive" data-noexport id="trusted-types-directive">trusted-types</dfn> directive</span><a class="self-link" href="#trusted-types-csp-directive"></a></h4>
    <p>This document defines <em>trusted-types</em> - a new <a href="https://www.w3.org/TR/CSP3/#directives">Content Security Policy directive</a>.</p>
    <p><code class="idl"><a data-link-type="idl">trusted-types</a></code> directive configures the Trusted
-Types framework for all the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①④">injection sinks</a> in a current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm" id="ref-for-concept-global-object-realm①">realm</a>. Specifically, it
+Types framework for all the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①③">injection sinks</a> in a current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm" id="ref-for-concept-global-object-realm①">realm</a>. Specifically, it
 defines which policies (identified by name) can be created, and what should
-be the behavior when a string value is passed to an <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑤">injection sink</a> (i.e. should the type-based enforcement be enabled).</p>
+be the behavior when a string value is passed to an <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①④">injection sink</a> (i.e. should the type-based enforcement be enabled).</p>
    <p>The syntax for the directive’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-name" id="ref-for-directive-name">name</a> and <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-value" id="ref-for-directive-value">value</a> is described by the following
 ABNF:</p>
 <pre>directive-name = "trusted-types"
@@ -2736,7 +2645,7 @@ directive-value = <a data-link-type="dfn" href="#serialized-tt-configuration" id
    </div>
    <div class="example" id="header-that-allows-no-policy-names">
     <a class="self-link" href="#header-that-allows-no-policy-names"></a> An empty <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directives" id="ref-for-directives">directive</a> <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-value" id="ref-for-directive-value①">value</a> indicates policies may not be created,
-and sinks expect Trusted Type values, i.e. no <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑥">injection sinks</a> can be used
+and sinks expect Trusted Type values, i.e. no <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑤">injection sinks</a> can be used
 at all. 
 <pre class="http">Content-Security-Policy: trusted-types
 </pre>
@@ -2747,7 +2656,7 @@ at all.
 <pre class="http">Content-Security-Policy: trusted-types *
 </pre>
    </div>
-   <p>If the policy named <code>default</code> is present in the list, it refers to the <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy①">default policy</a>. All strings passed to <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑦">injection sinks</a> will be passed through it instead
+   <p>If the policy named <code>default</code> is present in the list, it refers to the <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy①">default policy</a>. All strings passed to <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑥">injection sinks</a> will be passed through it instead
 of being rejected outright.</p>
    <div class="example" id="default-in-header">
     <a class="self-link" href="#default-in-header"></a> 
@@ -2765,11 +2674,11 @@ of being rejected outright.</p>
     <li data-md>
      <p>Let <var>encodedScriptSource</var> be the result of removing the leading <code>"javascript:"</code> from <var>urlString</var>.</p>
     <li data-md>
-     <p>Let <var>defaultPolicy</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-get-default-policy" id="ref-for-abstract-opdef-get-default-policy①">Get default policy</a> algorithm on <var>source</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy②">WindowProxy</a></code>'s <a data-link-type="dfn" href="#window-trusted-type-policy-factory" id="ref-for-window-trusted-type-policy-factory③">trusted type policy factory</a>.</p>
+     <p>Let <var>defaultPolicy</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-get-default-policy" id="ref-for-abstract-opdef-get-default-policy①">Get default policy</a> algorithm on <var>source</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy">WindowProxy</a></code>'s <a data-link-type="dfn" href="#window-trusted-type-policy-factory" id="ref-for-window-trusted-type-policy-factory③">trusted type policy factory</a>.</p>
     <li data-md>
      <p>If <var>defaultPolicy</var> is <code>null</code>, return <code>"Blocked"</code> and abort further steps.</p>
     <li data-md>
-     <p>Let <var>covertedScriptSource</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-trusted-type" id="ref-for-abstract-opdef-create-a-trusted-type⑤">Create a Trusted Type</a> algorithm, with the following arguments:</p>
+     <p>Let <var>covertedScriptSource</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-trusted-type" id="ref-for-abstract-opdef-create-a-trusted-type④">Create a Trusted Type</a> algorithm, with the following arguments:</p>
      <ul>
       <li data-md>
        <p><var>defaultPolicy</var> as <var>policy</var></p>
@@ -2795,7 +2704,7 @@ of being rejected outright.</p>
    </ol>
    <h4 class="heading settled" data-level="4.5.2" id="should-block-sink-type-mismatch"><span class="secno">4.5.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy">Should sink type mismatch violation be blocked by Content Security Policy?</dfn></span><a class="self-link" href="#should-block-sink-type-mismatch"></a></h4>
    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global②">global object</a> (<var>global</var>), a string (<var>sink</var>) and a string (<var>source</var>) this algorithm
-returns <code>"Blocked"</code> if the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑧">injection sink</a> requires a <a data-link-type="dfn" href="#trusted-type" id="ref-for-trusted-type⑤">Trusted Type</a>, and <code>"Allowed"</code> otherwise.</p>
+returns <code>"Blocked"</code> if the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑦">injection sink</a> requires a <a data-link-type="dfn" href="#trusted-type" id="ref-for-trusted-type⑤">Trusted Type</a>, and <code>"Allowed"</code> otherwise.</p>
    <ol>
     <li data-md>
      <p>Let <var>result</var> be <code>"Allowed"</code>.</p>
@@ -3048,7 +2957,7 @@ together.</p>
 NOT interfere with the operation of user-agent features like addons,
 extensions, or bookmarklets. These kinds of features generally advance
 the user’s priority over page authors, as espoused in <a data-link-type="biblio" href="#biblio-html-design-principles">[html-design-principles]</a>. Specifically, extensions SHOULD be able to pass strings
-to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑨">injection sinks</a> without triggering <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy⑤">default policy</a> execution, violation generation, or the rejection of the value.</p>
+to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑧">injection sinks</a> without triggering <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy⑤">default policy</a> execution, violation generation, or the rejection of the value.</p>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -3199,9 +3108,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dom-htmlformelement-action">action</a><span>, in §4.1.4</span>
-   <li><a href="#dom-location-assign">assign(url)</a><span>, in §4.1.3</span>
-   <li><a href="#dom-htmlobjectelement-codebase">codeBase</a><span>, in §4.1.4</span>
+   <li><a href="#dom-htmlobjectelement-codebase">codeBase</a><span>, in §4.1.3</span>
    <li><a href="#abstract-opdef-create-a-trusted-type">Create a Trusted Type</a><span>, in §3.3</span>
    <li><a href="#abstract-opdef-create-a-trusted-type-policy">Create a Trusted Type Policy</a><span>, in §3.1</span>
    <li><a href="#dom-range-createcontextualfragment">createContextualFragment(fragment)</a><span>, in §4.4</span>
@@ -3216,22 +3123,13 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <li><a href="#dom-trustedtypepolicyoptions-createscripturl">createScriptURL</a><span>, in §2.3.3</span>
    <li><a href="#callbackdef-createscripturlcallback">CreateScriptURLCallback</a><span>, in §2.3.3</span>
    <li><a href="#dom-trustedtypepolicy-createscripturl">createScriptURL(input, ...arguments)</a><span>, in §2.3.2</span>
-   <li><a href="#dom-trustedtypepolicyoptions-createurl">createURL</a><span>, in §2.3.3</span>
-   <li><a href="#callbackdef-createurlcallback">CreateURLCallback</a><span>, in §2.3.3</span>
-   <li><a href="#dom-trustedtypepolicy-createurl">createURL(input, ...arguments)</a><span>, in §2.3.2</span>
-   <li><a href="#dom-htmlobjectelement-data">data</a><span>, in §4.1.4</span>
+   <li><a href="#dom-htmlobjectelement-data">data</a><span>, in §4.1.3</span>
    <li><a href="#default-policy">Default policy</a><span>, in §2.3.4</span>
    <li><a href="#dom-trustedtypepolicyfactory-defaultpolicy">defaultPolicy</a><span>, in §2.3.1</span>
-   <li><a href="#domparser">DOMParser</a><span>, in §4.4</span>
    <li><a href="#dom-domparser-domparser">DOMParser()</a><span>, in §4.4</span>
+   <li><a href="#domparser">DOMParser</a><span>, in §4.4</span>
    <li><a href="#dom-trustedtypepolicyfactory-emptyhtml">emptyHTML</a><span>, in §2.3.1</span>
    <li><a href="#enforcement">Enforcement</a><span>, in §2.4</span>
-   <li>
-    formAction
-    <ul>
-     <li><a href="#dom-htmlbuttonelement-formaction">attribute for HTMLButtonElement</a><span>, in §4.1.4</span>
-     <li><a href="#dom-htmlinputelement-formaction">attribute for HTMLInputElement</a><span>, in §4.1.4</span>
-    </ul>
    <li><a href="#dom-trustedtypepolicyfactory-getattributetype">getAttributeType(tagName, attribute)</a><span>, in §2.3.1</span>
    <li><a href="#dom-trustedtypepolicyfactory-getattributetype">getAttributeType(tagName, attribute, elementNs)</a><span>, in §2.3.1</span>
    <li><a href="#dom-trustedtypepolicyfactory-getattributetype">getAttributeType(tagName, attribute, elementNs, attrNs)</a><span>, in §2.3.1</span>
@@ -3240,27 +3138,18 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <li><a href="#dom-trustedtypepolicyfactory-getpropertytype">getPropertyType(tagName, property)</a><span>, in §2.3.1</span>
    <li><a href="#dom-trustedtypepolicyfactory-getpropertytype">getPropertyType(tagName, property, elementNs)</a><span>, in §2.3.1</span>
    <li><a href="#abstract-opdef-get-trusted-type-compliant-string">Get Trusted Type compliant string</a><span>, in §3.4</span>
-   <li>
-    href
-    <ul>
-     <li><a href="#dom-htmlbaseelement-href">attribute for HTMLBaseElement</a><span>, in §4.1.4</span>
-     <li><a href="#dom-htmlhyperlinkelementutils-href">attribute for HTMLHyperlinkElementUtils</a><span>, in §4.1.4</span>
-     <li><a href="#dom-location-href">attribute for Location</a><span>, in §4.1.3</span>
-     <li><a href="#dom-svgscriptelement-href">attribute for SVGScriptElement</a><span>, in §4.2</span>
-     <li><a href="#dom-svgurireference-href">attribute for SVGURIReference</a><span>, in §4.2</span>
-    </ul>
+   <li><a href="#dom-svgscriptelement-href">href</a><span>, in §4.2</span>
    <li><a href="#typedefdef-htmlstring">HTMLString</a><span>, in §4</span>
    <li><a href="#typedefdef-htmlstringdefaultsempty">HTMLStringDefaultsEmpty</a><span>, in §4</span>
    <li><a href="#injection-sink">injection sink</a><span>, in §2.1</span>
    <li><a href="#dom-innerhtml-innerhtml">innerHTML</a><span>, in §4.4</span>
-   <li><a href="#dom-htmlscriptelement-innertext">innerText</a><span>, in §4.1.5</span>
+   <li><a href="#dom-htmlscriptelement-innertext">innerText</a><span>, in §4.1.4</span>
    <li><a href="#dom-element-insertadjacenthtml">insertAdjacentHTML(position, text)</a><span>, in §4.4</span>
    <li><a href="#abstract-opdef-insert-text-node-validation-steps">insert text node validation steps</a><span>, in §4.3.1</span>
    <li><a href="#dom-trustedtypepolicyfactory-ishtml">isHTML(value)</a><span>, in §2.3.1</span>
    <li><a href="#dom-trustedtypepolicyfactory-isscripturl">isScriptURL(value)</a><span>, in §2.3.1</span>
    <li><a href="#dom-trustedtypepolicyfactory-isscript">isScript(value)</a><span>, in §2.3.1</span>
    <li><a href="#abstract-opdef-issourceexempt">IsSourceExempt</a><span>, in §4.5.6</span>
-   <li><a href="#dom-trustedtypepolicyfactory-isurl">isURL(value)</a><span>, in §2.3.1</span>
    <li><a href="#grammardef-keyword-source">keyword-source</a><span>, in §4.5.5</span>
    <li>
     name
@@ -3268,47 +3157,35 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><a href="#dom-trustedtypepolicy-name">attribute for TrustedTypePolicy</a><span>, in §2.3.2</span>
      <li><a href="#trustedtypepolicy-name">dfn for TrustedTypePolicy</a><span>, in §2.3.2</span>
     </ul>
-   <li><a href="#dom-window-open">open()</a><span>, in §4.1.1</span>
-   <li><a href="#dom-window-open">open(url)</a><span>, in §4.1.1</span>
-   <li><a href="#dom-document-open">open(url, name, features)</a><span>, in §4.1.2</span>
-   <li><a href="#dom-window-open">open(url, target)</a><span>, in §4.1.1</span>
-   <li><a href="#dom-window-open">open(url, target, features)</a><span>, in §4.1.1</span>
    <li><a href="#dom-element-outerhtml">outerHTML</a><span>, in §4.4</span>
    <li><a href="#dom-domparser-parsefromstring">parseFromString(str, type)</a><span>, in §4.4</span>
-   <li><a href="#dom-location-replace">replace(url)</a><span>, in §4.1.3</span>
    <li><a href="#typedefdef-scriptstring">ScriptString</a><span>, in §4</span>
    <li><a href="#typedefdef-scripturlstring">ScriptURLString</a><span>, in §4</span>
    <li><a href="#serialized-tt-configuration">serialized-tt-configuration</a><span>, in §4.5.1</span>
-   <li><a href="#dom-windoworworkerglobalscope-setinterval">setInterval(handler)</a><span>, in §4.1.6</span>
-   <li><a href="#dom-windoworworkerglobalscope-setinterval">setInterval(handler, timeout)</a><span>, in §4.1.6</span>
-   <li><a href="#dom-windoworworkerglobalscope-setinterval">setInterval(handler, timeout, ...arguments)</a><span>, in §4.1.6</span>
-   <li><a href="#dom-windoworworkerglobalscope-settimeout">setTimeout(handler)</a><span>, in §4.1.6</span>
-   <li><a href="#dom-windoworworkerglobalscope-settimeout">setTimeout(handler, timeout)</a><span>, in §4.1.6</span>
-   <li><a href="#dom-windoworworkerglobalscope-settimeout">setTimeout(handler, timeout, ...arguments)</a><span>, in §4.1.6</span>
+   <li><a href="#dom-windoworworkerglobalscope-setinterval">setInterval(handler)</a><span>, in §4.1.5</span>
+   <li><a href="#dom-windoworworkerglobalscope-setinterval">setInterval(handler, timeout)</a><span>, in §4.1.5</span>
+   <li><a href="#dom-windoworworkerglobalscope-setinterval">setInterval(handler, timeout, ...arguments)</a><span>, in §4.1.5</span>
+   <li><a href="#dom-windoworworkerglobalscope-settimeout">setTimeout(handler)</a><span>, in §4.1.5</span>
+   <li><a href="#dom-windoworworkerglobalscope-settimeout">setTimeout(handler, timeout)</a><span>, in §4.1.5</span>
+   <li><a href="#dom-windoworworkerglobalscope-settimeout">setTimeout(handler, timeout, ...arguments)</a><span>, in §4.1.5</span>
    <li><a href="#abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy">Should sink type mismatch violation be blocked by Content Security Policy?</a><span>, in §4.5.2</span>
    <li><a href="#abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy">Should Trusted Type policy creation be blocked by Content Security Policy?</a><span>, in §4.5.3</span>
    <li>
     src
     <ul>
-     <li><a href="#dom-htmlembedelement-src">attribute for HTMLEmbedElement</a><span>, in §4.1.4</span>
-     <li><a href="#dom-htmlframeelement-src">attribute for HTMLFrameElement</a><span>, in §4.1.4</span>
-     <li><a href="#dom-htmliframeelement-src">attribute for HTMLIFrameElement</a><span>, in §4.1.4</span>
-     <li><a href="#dom-htmlinputelement-src">attribute for HTMLInputElement</a><span>, in §4.1.4</span>
-     <li><a href="#dom-htmlscriptelement-src">attribute for HTMLScriptElement</a><span>, in §4.1.4</span>
+     <li><a href="#dom-htmlembedelement-src">attribute for HTMLEmbedElement</a><span>, in §4.1.3</span>
+     <li><a href="#dom-htmlscriptelement-src">attribute for HTMLScriptElement</a><span>, in §4.1.3</span>
     </ul>
-   <li><a href="#dom-htmliframeelement-srcdoc">srcdoc</a><span>, in §4.1.4</span>
+   <li><a href="#dom-htmliframeelement-srcdoc">srcdoc</a><span>, in §4.1.3</span>
    <li>
     stringification behavior
     <ul>
-     <li><a href="#HTMLHyperlinkElementUtils-stringification-behavior">dfn for HTMLHyperlinkElementUtils</a><span>, in §4.1.4</span>
-     <li><a href="#Location-stringification-behavior">dfn for Location</a><span>, in §4.1.3</span>
      <li><a href="#TrustedHTML-stringification-behavior">dfn for TrustedHTML</a><span>, in §2.2.1</span>
      <li><a href="#TrustedScript-stringification-behavior">dfn for TrustedScript</a><span>, in §2.2.2</span>
      <li><a href="#TrustedScriptURL-stringification-behavior">dfn for TrustedScriptURL</a><span>, in §2.2.3</span>
-     <li><a href="#TrustedURL-stringification-behavior">dfn for TrustedURL</a><span>, in §2.2.4</span>
     </ul>
-   <li><a href="#dom-htmlscriptelement-text">text</a><span>, in §4.1.4</span>
-   <li><a href="#dom-htmlscriptelement-textcontent">textContent</a><span>, in §4.1.5</span>
+   <li><a href="#dom-htmlscriptelement-text">text</a><span>, in §4.1.3</span>
+   <li><a href="#dom-htmlscriptelement-textcontent">textContent</a><span>, in §4.1.4</span>
    <li>
     TrustedHTML
     <ul>
@@ -3328,7 +3205,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><a href="#trustedscripturl">(interface)</a><span>, in §2.2.3</span>
      <li><a href="#typedef-trustedscripturl">(type)</a><span>, in §2.2.3</span>
     </ul>
-   <li><a href="#typedefdef-trustedtimerhandler">TrustedTimerHandler</a><span>, in §4.1.6</span>
+   <li><a href="#typedefdef-trustedtimerhandler">TrustedTimerHandler</a><span>, in §4.1.5</span>
    <li><a href="#typedefdef-trustedtype">TrustedType</a><span>, in §4</span>
    <li><a href="#trusted-type">Trusted Type</a><span>, in §2.2</span>
    <li>
@@ -3350,18 +3227,11 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><a href="#dictdef-trustedtypepolicyoptions">(dictionary)</a><span>, in §2.3.3</span>
      <li><a href="#typedef-trustedtypepolicyoptions">(type)</a><span>, in §2.3.3</span>
     </ul>
-   <li><a href="#extendedattrdef-trustedtypes">TrustedTypes</a><span>, in §2.4.2</span>
    <li><a href="#dom-window-trustedtypes">trustedTypes</a><span>, in §4.1.1</span>
+   <li><a href="#extendedattrdef-trustedtypes">TrustedTypes</a><span>, in §2.4.2</span>
    <li><a href="#trusted-types-directive">trusted-types-directive</a><span>, in §4.5.1</span>
-   <li>
-    TrustedURL
-    <ul>
-     <li><a href="#trustedurl">(interface)</a><span>, in §2.2.4</span>
-     <li><a href="#typedef-trustedurl">(type)</a><span>, in §2.2.4</span>
-    </ul>
    <li><a href="#tt-expression">tt-expression</a><span>, in §4.5.1</span>
    <li><a href="#tt-policy-name">tt-policy-name</a><span>, in §4.5.1</span>
-   <li><a href="#typedefdef-urlstring">URLString</a><span>, in §4</span>
    <li><a href="#dom-document-write">write()</a><span>, in §4.1.2</span>
    <li><a href="#dom-document-writeln">writeln()</a><span>, in §4.1.2</span>
    <li><a href="#dom-document-writeln">writeln(...text)</a><span>, in §4.1.2</span>
@@ -3403,7 +3273,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-concept-child-text-content">
    <a href="https://dom.spec.whatwg.org/#concept-child-text-content">https://dom.spec.whatwg.org/#concept-child-text-content</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-child-text-content">4.1.5. Enforcement for script text contents</a> <a href="#ref-for-concept-child-text-content①">(2)</a>
+    <li><a href="#ref-for-concept-child-text-content">4.1.4. Enforcement for script text contents</a> <a href="#ref-for-concept-child-text-content①">(2)</a>
     <li><a href="#ref-for-concept-child-text-content②">4.2. Integration with SVG</a>
    </ul>
   </aside>
@@ -3412,7 +3282,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <ul>
     <li><a href="#ref-for-context-object">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-context-object①">(2)</a>
     <li><a href="#ref-for-context-object②">2.4.2. TrustedTypes extended attribute</a> <a href="#ref-for-context-object③">(2)</a> <a href="#ref-for-context-object④">(3)</a> <a href="#ref-for-context-object⑤">(4)</a> <a href="#ref-for-context-object⑥">(5)</a> <a href="#ref-for-context-object⑦">(6)</a> <a href="#ref-for-context-object⑧">(7)</a> <a href="#ref-for-context-object⑨">(8)</a> <a href="#ref-for-context-object①⓪">(9)</a> <a href="#ref-for-context-object①①">(10)</a>
-    <li><a href="#ref-for-context-object①②">4.1.6. Enforcement in timer functions</a>
+    <li><a href="#ref-for-context-object①②">4.1.5. Enforcement in timer functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-namednodemap-element">
@@ -3432,13 +3302,13 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <a href="https://dom.spec.whatwg.org/#concept-element-local-name">https://dom.spec.whatwg.org/#concept-element-local-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-local-name">2.4.2. TrustedTypes extended attribute</a> <a href="#ref-for-concept-element-local-name①">(2)</a>
-    <li><a href="#ref-for-concept-element-local-name②">4.1.7. Enforcement in event handler content attributes</a>
+    <li><a href="#ref-for-concept-element-local-name②">4.1.6. Enforcement in event handler content attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-node-textcontent">
    <a href="https://dom.spec.whatwg.org/#dom-node-textcontent">https://dom.spec.whatwg.org/#dom-node-textcontent</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-node-textcontent">4.1.5. Enforcement for script text contents</a>
+    <li><a href="#ref-for-dom-node-textcontent">4.1.4. Enforcement for script text contents</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-h-the-domparser-interface">
@@ -3463,83 +3333,41 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">4.1.2. Extensions to the Document interface</a> <a href="#ref-for-cereactions①">(2)</a>
-    <li><a href="#ref-for-cereactions②">4.1.4. Enforcement in element attributes</a> <a href="#ref-for-cereactions③">(2)</a> <a href="#ref-for-cereactions④">(3)</a> <a href="#ref-for-cereactions⑤">(4)</a> <a href="#ref-for-cereactions⑥">(5)</a> <a href="#ref-for-cereactions⑦">(6)</a> <a href="#ref-for-cereactions⑧">(7)</a> <a href="#ref-for-cereactions⑨">(8)</a> <a href="#ref-for-cereactions①⓪">(9)</a> <a href="#ref-for-cereactions①①">(10)</a> <a href="#ref-for-cereactions①②">(11)</a> <a href="#ref-for-cereactions①③">(12)</a> <a href="#ref-for-cereactions①④">(13)</a> <a href="#ref-for-cereactions①⑤">(14)</a>
-    <li><a href="#ref-for-cereactions①⑥">4.1.5. Enforcement for script text contents</a> <a href="#ref-for-cereactions①⑦">(2)</a>
-    <li><a href="#ref-for-cereactions①⑧">4.4. Integration with DOM Parsing</a> <a href="#ref-for-cereactions①⑨">(2)</a> <a href="#ref-for-cereactions②⓪">(3)</a> <a href="#ref-for-cereactions②①">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlbaseelement">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlbaseelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlbaseelement</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-htmlbaseelement">4.1.4. Enforcement in element attributes</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlbuttonelement">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-htmlbuttonelement">4.1.4. Enforcement in element attributes</a>
+    <li><a href="#ref-for-cereactions②">4.1.3. Enforcement in element attributes</a> <a href="#ref-for-cereactions③">(2)</a> <a href="#ref-for-cereactions④">(3)</a> <a href="#ref-for-cereactions⑤">(4)</a> <a href="#ref-for-cereactions⑥">(5)</a> <a href="#ref-for-cereactions⑦">(6)</a>
+    <li><a href="#ref-for-cereactions⑧">4.1.4. Enforcement for script text contents</a> <a href="#ref-for-cereactions⑨">(2)</a>
+    <li><a href="#ref-for-cereactions①⓪">4.4. Integration with DOM Parsing</a> <a href="#ref-for-cereactions①①">(2)</a> <a href="#ref-for-cereactions①②">(3)</a> <a href="#ref-for-cereactions①③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-htmlelement">
    <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlelement">4.1.4. Enforcement in element attributes</a> <a href="#ref-for-htmlelement①">(2)</a> <a href="#ref-for-htmlelement②">(3)</a> <a href="#ref-for-htmlelement③">(4)</a> <a href="#ref-for-htmlelement④">(5)</a> <a href="#ref-for-htmlelement⑤">(6)</a> <a href="#ref-for-htmlelement⑥">(7)</a> <a href="#ref-for-htmlelement⑦">(8)</a> <a href="#ref-for-htmlelement⑧">(9)</a>
-    <li><a href="#ref-for-htmlelement⑨">4.1.5. Enforcement for script text contents</a>
+    <li><a href="#ref-for-htmlelement">4.1.3. Enforcement in element attributes</a> <a href="#ref-for-htmlelement①">(2)</a> <a href="#ref-for-htmlelement②">(3)</a> <a href="#ref-for-htmlelement③">(4)</a>
+    <li><a href="#ref-for-htmlelement④">4.1.4. Enforcement for script text contents</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-htmlembedelement">
    <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlembedelement">4.1.4. Enforcement in element attributes</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlformelement">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">https://html.spec.whatwg.org/multipage/forms.html#htmlformelement</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-htmlformelement">4.1.4. Enforcement in element attributes</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlframeelement">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#htmlframeelement">https://html.spec.whatwg.org/multipage/obsolete.html#htmlframeelement</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-htmlframeelement">4.1.4. Enforcement in element attributes</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlhyperlinkelementutils">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils">https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-htmlhyperlinkelementutils">4.1.4. Enforcement in element attributes</a>
+    <li><a href="#ref-for-htmlembedelement">4.1.3. Enforcement in element attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-htmliframeelement">
    <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmliframeelement">4.1.4. Enforcement in element attributes</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlinputelement">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement">https://html.spec.whatwg.org/multipage/input.html#htmlinputelement</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-htmlinputelement">4.1.4. Enforcement in element attributes</a>
+    <li><a href="#ref-for-htmliframeelement">4.1.3. Enforcement in element attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-htmlobjectelement">
    <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlobjectelement">4.1.4. Enforcement in element attributes</a>
+    <li><a href="#ref-for-htmlobjectelement">4.1.3. Enforcement in element attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-htmlscriptelement">
    <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlscriptelement">4.1.4. Enforcement in element attributes</a>
-    <li><a href="#ref-for-htmlscriptelement①">4.1.5. Enforcement for script text contents</a> <a href="#ref-for-htmlscriptelement②">(2)</a> <a href="#ref-for-htmlscriptelement③">(3)</a> <a href="#ref-for-htmlscriptelement④">(4)</a> <a href="#ref-for-htmlscriptelement⑤">(5)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-location">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#location">https://html.spec.whatwg.org/multipage/history.html#location</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-location">4.1.3. Extensions to the Location interface</a> <a href="#ref-for-location①">(2)</a>
+    <li><a href="#ref-for-htmlscriptelement">4.1.3. Enforcement in element attributes</a>
+    <li><a href="#ref-for-htmlscriptelement①">4.1.4. Enforcement for script text contents</a> <a href="#ref-for-htmlscriptelement②">(2)</a> <a href="#ref-for-htmlscriptelement③">(3)</a> <a href="#ref-for-htmlscriptelement④">(4)</a> <a href="#ref-for-htmlscriptelement⑤">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-window">
@@ -3553,15 +3381,13 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-windoworworkerglobalscope">4.1.6. Enforcement in timer functions</a> <a href="#ref-for-windoworworkerglobalscope①">(2)</a>
+    <li><a href="#ref-for-windoworworkerglobalscope">4.1.5. Enforcement in timer functions</a> <a href="#ref-for-windoworworkerglobalscope①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-windowproxy">
    <a href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy">https://html.spec.whatwg.org/multipage/window-object.html#windowproxy</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-windowproxy">4.1.1. Extensions to the Window interface</a>
-    <li><a href="#ref-for-windowproxy①">4.1.2. Extensions to the Document interface</a>
-    <li><a href="#ref-for-windowproxy②">4.5.1.1. trusted-types Pre-Navigation check</a>
+    <li><a href="#ref-for-windowproxy">4.5.1.1. trusted-types Pre-Navigation check</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-browsing-context">
@@ -3592,7 +3418,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-dom-innertext">
    <a href="https://html.spec.whatwg.org/multipage/dom.html#dom-innertext">https://html.spec.whatwg.org/multipage/dom.html#dom-innertext</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-innertext">4.1.5. Enforcement for script text contents</a>
+    <li><a href="#ref-for-dom-innertext">4.1.4. Enforcement for script text contents</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-global-object-realm">
@@ -3613,9 +3439,9 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <ul>
     <li><a href="#ref-for-concept-relevant-global">2.3.1. TrustedTypePolicyFactory</a>
     <li><a href="#ref-for-concept-relevant-global①">2.4.2. TrustedTypes extended attribute</a> <a href="#ref-for-concept-relevant-global②">(2)</a> <a href="#ref-for-concept-relevant-global③">(3)</a> <a href="#ref-for-concept-relevant-global④">(4)</a>
-    <li><a href="#ref-for-concept-relevant-global⑤">4.1.5. Enforcement for script text contents</a>
-    <li><a href="#ref-for-concept-relevant-global⑥">4.1.6. Enforcement in timer functions</a>
-    <li><a href="#ref-for-concept-relevant-global⑦">4.1.7. Enforcement in event handler content attributes</a>
+    <li><a href="#ref-for-concept-relevant-global⑤">4.1.4. Enforcement for script text contents</a>
+    <li><a href="#ref-for-concept-relevant-global⑥">4.1.5. Enforcement in timer functions</a>
+    <li><a href="#ref-for-concept-relevant-global⑦">4.1.6. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-concept-relevant-global⑧">4.2. Integration with SVG</a>
    </ul>
   </aside>
@@ -3635,7 +3461,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-concatenate">2.4.2. TrustedTypes extended attribute</a> <a href="#ref-for-string-concatenate①">(2)</a>
-    <li><a href="#ref-for-string-concatenate②">4.1.7. Enforcement in event handler content attributes</a>
+    <li><a href="#ref-for-string-concatenate②">4.1.6. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-string-concatenate③">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
    </ul>
   </aside>
@@ -3657,12 +3483,6 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-ordered-set">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGAnimatedString">
-   <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString">https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-InterfaceSVGAnimatedString">4.2. Integration with SVG</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-InterfaceSVGElement">
    <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement">https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement</a><b>Referenced in:</b>
    <ul>
@@ -3673,12 +3493,6 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <a href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement">https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGScriptElement">4.2. Integration with SVG</a> <a href="#ref-for-InterfaceSVGScriptElement①">(2)</a> <a href="#ref-for-InterfaceSVGScriptElement②">(3)</a> <a href="#ref-for-InterfaceSVGScriptElement③">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGURIReference">
-   <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGURIReference">https://svgwg.org/svg2-draft/types.html#InterfaceSVGURIReference</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-InterfaceSVGURIReference">4.2. Integration with SVG</a> <a href="#ref-for-InterfaceSVGURIReference①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
@@ -3703,13 +3517,11 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a> <a href="#ref-for-idl-DOMString⑤">(6)</a> <a href="#ref-for-idl-DOMString⑥">(7)</a> <a href="#ref-for-idl-DOMString⑦">(8)</a> <a href="#ref-for-idl-DOMString⑧">(9)</a> <a href="#ref-for-idl-DOMString⑨">(10)</a> <a href="#ref-for-idl-DOMString①⓪">(11)</a>
-    <li><a href="#ref-for-idl-DOMString①①">2.3.2. TrustedTypePolicy</a> <a href="#ref-for-idl-DOMString①②">(2)</a> <a href="#ref-for-idl-DOMString①③">(3)</a> <a href="#ref-for-idl-DOMString①④">(4)</a> <a href="#ref-for-idl-DOMString①⑤">(5)</a>
-    <li><a href="#ref-for-idl-DOMString①⑥">2.3.3. TrustedTypePolicyOptions</a> <a href="#ref-for-idl-DOMString①⑦">(2)</a> <a href="#ref-for-idl-DOMString①⑧">(3)</a> <a href="#ref-for-idl-DOMString①⑨">(4)</a> <a href="#ref-for-idl-DOMString②⓪">(5)</a> <a href="#ref-for-idl-DOMString②①">(6)</a>
-    <li><a href="#ref-for-idl-DOMString②②">4. Integrations</a> <a href="#ref-for-idl-DOMString②③">(2)</a> <a href="#ref-for-idl-DOMString②④">(3)</a>
-    <li><a href="#ref-for-idl-DOMString②⑤">4.1.1. Extensions to the Window interface</a> <a href="#ref-for-idl-DOMString②⑥">(2)</a>
-    <li><a href="#ref-for-idl-DOMString②⑦">4.1.2. Extensions to the Document interface</a> <a href="#ref-for-idl-DOMString②⑧">(2)</a>
-    <li><a href="#ref-for-idl-DOMString②⑨">4.1.4. Enforcement in element attributes</a>
-    <li><a href="#ref-for-idl-DOMString③⓪">4.4. Integration with DOM Parsing</a>
+    <li><a href="#ref-for-idl-DOMString①①">2.3.2. TrustedTypePolicy</a> <a href="#ref-for-idl-DOMString①②">(2)</a> <a href="#ref-for-idl-DOMString①③">(3)</a> <a href="#ref-for-idl-DOMString①④">(4)</a>
+    <li><a href="#ref-for-idl-DOMString①⑤">2.3.3. TrustedTypePolicyOptions</a> <a href="#ref-for-idl-DOMString①⑥">(2)</a> <a href="#ref-for-idl-DOMString①⑦">(3)</a> <a href="#ref-for-idl-DOMString①⑧">(4)</a> <a href="#ref-for-idl-DOMString①⑨">(5)</a>
+    <li><a href="#ref-for-idl-DOMString②⓪">4. Integrations</a> <a href="#ref-for-idl-DOMString②①">(2)</a> <a href="#ref-for-idl-DOMString②②">(3)</a>
+    <li><a href="#ref-for-idl-DOMString②③">4.1.3. Enforcement in element attributes</a>
+    <li><a href="#ref-for-idl-DOMString②④">4.4. Integration with DOM Parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-exceptiondef-evalerror">
@@ -3724,16 +3536,15 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-Exposed">2.2.1. TrustedHTML</a>
     <li><a href="#ref-for-Exposed①">2.2.2. TrustedScript</a>
     <li><a href="#ref-for-Exposed②">2.2.3. TrustedScriptURL</a>
-    <li><a href="#ref-for-Exposed③">2.2.4. TrustedURL</a>
-    <li><a href="#ref-for-Exposed④">2.3.1. TrustedTypePolicyFactory</a>
-    <li><a href="#ref-for-Exposed⑤">2.3.2. TrustedTypePolicy</a>
-    <li><a href="#ref-for-Exposed⑥">4.4. Integration with DOM Parsing</a>
+    <li><a href="#ref-for-Exposed③">2.3.1. TrustedTypePolicyFactory</a>
+    <li><a href="#ref-for-Exposed④">2.3.2. TrustedTypePolicy</a>
+    <li><a href="#ref-for-Exposed⑤">4.4. Integration with DOM Parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Function">
    <a href="https://heycam.github.io/webidl/#Function">https://heycam.github.io/webidl/#Function</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Function">4.1.6. Enforcement in timer functions</a> <a href="#ref-for-Function①">(2)</a> <a href="#ref-for-Function②">(3)</a>
+    <li><a href="#ref-for-Function">4.1.5. Enforcement in timer functions</a> <a href="#ref-for-Function①">(2)</a> <a href="#ref-for-Function②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-NewObject">
@@ -3742,18 +3553,11 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-NewObject">4.4. Integration with DOM Parsing</a> <a href="#ref-for-NewObject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://heycam.github.io/webidl/#SameObject">https://heycam.github.io/webidl/#SameObject</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-SameObject">4.2. Integration with SVG</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-TreatNullAs">
    <a href="https://heycam.github.io/webidl/#TreatNullAs">https://heycam.github.io/webidl/#TreatNullAs</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TreatNullAs">4. Integrations</a>
-    <li><a href="#ref-for-TreatNullAs①">4.1.1. Extensions to the Window interface</a>
-    <li><a href="#ref-for-TreatNullAs②">4.1.5. Enforcement for script text contents</a>
+    <li><a href="#ref-for-TreatNullAs①">4.1.4. Enforcement for script text contents</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
@@ -3767,17 +3571,16 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-idl-USVString">
    <a href="https://heycam.github.io/webidl/#idl-USVString">https://heycam.github.io/webidl/#idl-USVString</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-USVString">2.3.3. TrustedTypePolicyOptions</a> <a href="#ref-for-idl-USVString①">(2)</a>
-    <li><a href="#ref-for-idl-USVString②">4. Integrations</a> <a href="#ref-for-idl-USVString③">(2)</a>
+    <li><a href="#ref-for-idl-USVString">2.3.3. TrustedTypePolicyOptions</a>
+    <li><a href="#ref-for-idl-USVString①">4. Integrations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Unforgeable">
    <a href="https://heycam.github.io/webidl/#Unforgeable">https://heycam.github.io/webidl/#Unforgeable</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Unforgeable">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-Unforgeable①">(2)</a> <a href="#ref-for-Unforgeable②">(3)</a> <a href="#ref-for-Unforgeable③">(4)</a> <a href="#ref-for-Unforgeable④">(5)</a> <a href="#ref-for-Unforgeable⑤">(6)</a> <a href="#ref-for-Unforgeable⑥">(7)</a>
-    <li><a href="#ref-for-Unforgeable⑦">2.3.2. TrustedTypePolicy</a> <a href="#ref-for-Unforgeable⑧">(2)</a> <a href="#ref-for-Unforgeable⑨">(3)</a> <a href="#ref-for-Unforgeable①⓪">(4)</a> <a href="#ref-for-Unforgeable①①">(5)</a>
-    <li><a href="#ref-for-Unforgeable①②">4.1.1. Extensions to the Window interface</a>
-    <li><a href="#ref-for-Unforgeable①③">4.1.3. Extensions to the Location interface</a> <a href="#ref-for-Unforgeable①④">(2)</a> <a href="#ref-for-Unforgeable①⑤">(3)</a>
+    <li><a href="#ref-for-Unforgeable">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-Unforgeable①">(2)</a> <a href="#ref-for-Unforgeable②">(3)</a> <a href="#ref-for-Unforgeable③">(4)</a> <a href="#ref-for-Unforgeable④">(5)</a> <a href="#ref-for-Unforgeable⑤">(6)</a>
+    <li><a href="#ref-for-Unforgeable⑥">2.3.2. TrustedTypePolicy</a> <a href="#ref-for-Unforgeable⑦">(2)</a> <a href="#ref-for-Unforgeable⑧">(3)</a> <a href="#ref-for-Unforgeable⑨">(4)</a>
+    <li><a href="#ref-for-Unforgeable①⓪">4.1.1. Extensions to the Window interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-attribute">
@@ -3790,7 +3593,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-idl-boolean">
    <a href="https://heycam.github.io/webidl/#idl-boolean">https://heycam.github.io/webidl/#idl-boolean</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-boolean">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a> <a href="#ref-for-idl-boolean③">(4)</a>
+    <li><a href="#ref-for-idl-boolean">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-extended-attribute">
@@ -3814,7 +3617,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-idl-long">
    <a href="https://heycam.github.io/webidl/#idl-long">https://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-long">4.1.6. Enforcement in timer functions</a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a>
+    <li><a href="#ref-for-idl-long">4.1.5. Enforcement in timer functions</a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dfn-operation">
@@ -3867,18 +3670,11 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-cereactions" style="color:initial">CEReactions</span>
-     <li><span class="dfn-paneled" id="term-for-htmlbaseelement" style="color:initial">HTMLBaseElement</span>
-     <li><span class="dfn-paneled" id="term-for-htmlbuttonelement" style="color:initial">HTMLButtonElement</span>
      <li><span class="dfn-paneled" id="term-for-htmlelement" style="color:initial">HTMLElement</span>
      <li><span class="dfn-paneled" id="term-for-htmlembedelement" style="color:initial">HTMLEmbedElement</span>
-     <li><span class="dfn-paneled" id="term-for-htmlformelement" style="color:initial">HTMLFormElement</span>
-     <li><span class="dfn-paneled" id="term-for-htmlframeelement" style="color:initial">HTMLFrameElement</span>
-     <li><span class="dfn-paneled" id="term-for-htmlhyperlinkelementutils" style="color:initial">HTMLHyperlinkElementUtils</span>
      <li><span class="dfn-paneled" id="term-for-htmliframeelement" style="color:initial">HTMLIFrameElement</span>
-     <li><span class="dfn-paneled" id="term-for-htmlinputelement" style="color:initial">HTMLInputElement</span>
      <li><span class="dfn-paneled" id="term-for-htmlobjectelement" style="color:initial">HTMLObjectElement</span>
      <li><span class="dfn-paneled" id="term-for-htmlscriptelement" style="color:initial">HTMLScriptElement</span>
-     <li><span class="dfn-paneled" id="term-for-location" style="color:initial">Location</span>
      <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
      <li><span class="dfn-paneled" id="term-for-windoworworkerglobalscope" style="color:initial">WindowOrWorkerGlobalScope</span>
      <li><span class="dfn-paneled" id="term-for-windowproxy" style="color:initial">WindowProxy</span>
@@ -3903,10 +3699,8 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <li>
     <a data-link-type="biblio">[SVG2]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-InterfaceSVGAnimatedString" style="color:initial">SVGAnimatedString</span>
      <li><span class="dfn-paneled" id="term-for-InterfaceSVGElement" style="color:initial">SVGElement</span>
      <li><span class="dfn-paneled" id="term-for-InterfaceSVGScriptElement" style="color:initial">SVGScriptElement</span>
-     <li><span class="dfn-paneled" id="term-for-InterfaceSVGURIReference" style="color:initial">SVGURIReference</span>
     </ul>
    <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
@@ -3923,7 +3717,6 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><span class="dfn-paneled" id="term-for-Exposed" style="color:initial">Exposed</span>
      <li><span class="dfn-paneled" id="term-for-Function" style="color:initial">Function</span>
      <li><span class="dfn-paneled" id="term-for-NewObject" style="color:initial">NewObject</span>
-     <li><span class="dfn-paneled" id="term-for-SameObject" style="color:initial">SameObject</span>
      <li><span class="dfn-paneled" id="term-for-TreatNullAs" style="color:initial">TreatNullAs</span>
      <li><span class="dfn-paneled" id="term-for-exceptiondef-typeerror" style="color:initial">TypeError</span>
      <li><span class="dfn-paneled" id="term-for-idl-USVString" style="color:initial">USVString</span>
@@ -3971,7 +3764,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <dd>Ian Hickson; et al. <a href="https://www.w3.org/TR/html5/">HTML5</a>. 27 March 2018. REC. URL: <a href="https://www.w3.org/TR/html5/">https://www.w3.org/TR/html5/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑦"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#trustedhtml"><code><c- g>TrustedHTML</c-></code></a> {
   <a href="#TrustedHTML-stringification-behavior"><c- b>stringifier</c-></a>;
 };
@@ -3986,21 +3779,15 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <a href="#TrustedScriptURL-stringification-behavior"><c- b>stringifier</c-></a>;
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
-<c- b>interface</c-> <a href="#trustedurl"><code><c- g>TrustedURL</c-></code></a> {
-  <a href="#TrustedURL-stringification-behavior"><c- b>stringifier</c-></a>;
-};
-
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④①"><c- g>Exposed</c-></a>=<c- n>Window</c->] <c- b>interface</c-> <a href="#trustedtypepolicyfactory"><code><c- g>TrustedTypePolicyFactory</c-></code></a> {
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①⑥"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑤①"><c- n>TrustedTypePolicy</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-createpolicy" id="ref-for-dom-trustedtypepolicyfactory-createpolicy②①"><c- g>createPolicy</c-></a>(
-        <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③②"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicyfactory-createpolicy-policyname-policyoptions-policyname"><code><c- g>policyName</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-trustedtypepolicyoptions" id="ref-for-dictdef-trustedtypepolicyoptions⑤"><c- n>TrustedTypePolicyOptions</c-></a> <a href="#dom-trustedtypepolicyfactory-createpolicy-policyname-policyoptions-policyoptions"><code><c- g>policyOptions</c-></code></a>);
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①⑦"><c- g>Unforgeable</c-></a>] <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①⓪"><c- b>DOMString</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-getpolicynames" id="ref-for-dom-trustedtypepolicyfactory-getpolicynames①"><c- g>getPolicyNames</c-></a>();
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable②①"><c- g>Unforgeable</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-ishtml" id="ref-for-dom-trustedtypepolicyfactory-ishtml①"><c- g>isHTML</c-></a>(<c- b>any</c-> <a href="#dom-trustedtypepolicyfactory-ishtml-value-value"><code><c- g>value</c-></code></a>);
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③①"><c- g>Exposed</c-></a>=<c- n>Window</c->] <c- b>interface</c-> <a href="#trustedtypepolicyfactory"><code><c- g>TrustedTypePolicyFactory</c-></code></a> {
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy④①"><c- n>TrustedTypePolicy</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-createpolicy" id="ref-for-dom-trustedtypepolicyfactory-createpolicy②①"><c- g>createPolicy</c-></a>(
+        <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑥"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicyfactory-createpolicy-policyname-policyoptions-policyname"><code><c- g>policyName</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-trustedtypepolicyoptions" id="ref-for-dictdef-trustedtypepolicyoptions⑤"><c- n>TrustedTypePolicyOptions</c-></a> <a href="#dom-trustedtypepolicyfactory-createpolicy-policyname-policyoptions-policyoptions"><code><c- g>policyOptions</c-></code></a>);
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①②"><c- g>Unforgeable</c-></a>] <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①⓪"><c- b>DOMString</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-getpolicynames" id="ref-for-dom-trustedtypepolicyfactory-getpolicynames①"><c- g>getPolicyNames</c-></a>();
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable②①"><c- g>Unforgeable</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-ishtml" id="ref-for-dom-trustedtypepolicyfactory-ishtml①"><c- g>isHTML</c-></a>(<c- b>any</c-> <a href="#dom-trustedtypepolicyfactory-ishtml-value-value"><code><c- g>value</c-></code></a>);
     [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable③①"><c- g>Unforgeable</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-isscript" id="ref-for-dom-trustedtypepolicyfactory-isscript①"><c- g>isScript</c-></a>(<c- b>any</c-> <a href="#dom-trustedtypepolicyfactory-isscript-value-value"><code><c- g>value</c-></code></a>);
     [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable④①"><c- g>Unforgeable</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-isscripturl" id="ref-for-dom-trustedtypepolicyfactory-isscripturl①"><c- g>isScriptURL</c-></a>(<c- b>any</c-> <a href="#dom-trustedtypepolicyfactory-isscripturl-value-value"><code><c- g>value</c-></code></a>);
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑤①"><c- g>Unforgeable</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-isurl" id="ref-for-dom-trustedtypepolicyfactory-isurl①"><c- g>isURL</c-></a>(<c- b>any</c-> <a href="#dom-trustedtypepolicyfactory-isurl-value-value"><code><c- g>value</c-></code></a>);
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑥①"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑧"><c- n>TrustedHTML</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="TrustedHTML" href="#dom-trustedtypepolicyfactory-emptyhtml" id="ref-for-dom-trustedtypepolicyfactory-emptyhtml①"><c- g>emptyHTML</c-></a>;
-    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①⓪"><c- b>DOMString</c-></a>? <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-getattributetype" id="ref-for-dom-trustedtypepolicyfactory-getattributetype①"><c- g>getAttributeType</c-></a>(
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑤①"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑧"><c- n>TrustedHTML</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="TrustedHTML" href="#dom-trustedtypepolicyfactory-emptyhtml" id="ref-for-dom-trustedtypepolicyfactory-emptyhtml①"><c- g>emptyHTML</c-></a>;
+    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑤"><c- b>DOMString</c-></a>? <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicyfactory-getattributetype" id="ref-for-dom-trustedtypepolicyfactory-getattributetype①"><c- g>getAttributeType</c-></a>(
         <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicyfactory-getattributetype-tagname-attribute-elementns-attrns-tagname"><code><c- g>tagName</c-></code></a>,
         <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicyfactory-getattributetype-tagname-attribute-elementns-attrns-attribute"><code><c- g>attribute</c-></code></a>,
         <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicyfactory-getattributetype-tagname-attribute-elementns-attrns-elementns"><code><c- g>elementNs</c-></code></a> = "",
@@ -4009,108 +3796,66 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
         <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicyfactory-getpropertytype-tagname-property-elementns-tagname"><code><c- g>tagName</c-></code></a>,
         <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑨①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicyfactory-getpropertytype-tagname-property-elementns-property"><code><c- g>property</c-></code></a>,
         <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⓪①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicyfactory-getpropertytype-tagname-property-elementns-elementns"><code><c- g>elementNs</c-></code></a> = "");
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑥①"><c- n>TrustedTypePolicy</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="TrustedTypePolicy?" href="#dom-trustedtypepolicyfactory-defaultpolicy" id="ref-for-dom-trustedtypepolicyfactory-defaultpolicy①"><c- g>defaultPolicy</c-></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#trustedtypepolicy" id="ref-for-trustedtypepolicy⑤①"><c- n>TrustedTypePolicy</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="TrustedTypePolicy?" href="#dom-trustedtypepolicyfactory-defaultpolicy" id="ref-for-dom-trustedtypepolicyfactory-defaultpolicy①"><c- g>defaultPolicy</c-></a>;
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#trustedtypepolicy"><code><c- g>TrustedTypePolicy</c-></code></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑦①"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①①"><c- b>DOMString</c-></a> <a data-readonly data-type="DOMString" href="#dom-trustedtypepolicy-name"><code><c- g>name</c-></code></a>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑧①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑤①"><c- n>TrustedHTML</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createhtml" id="ref-for-dom-trustedtypepolicy-createhtml①"><c- g>createHTML</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①②①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createhtml-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createhtml-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑨①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript①⑤"><c- n>TrustedScript</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscript" id="ref-for-dom-trustedtypepolicy-createscript②"><c- g>createScript</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①③①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createscript-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createscript-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①⓪①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl①①"><c- n>TrustedScriptURL</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscripturl" id="ref-for-dom-trustedtypepolicy-createscripturl②"><c- g>createScriptURL</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①④①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createscripturl-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createscripturl-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①①①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑨"><c- n>TrustedURL</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createurl" id="ref-for-dom-trustedtypepolicy-createurl②"><c- g>createURL</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑤①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createurl-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createurl-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑥①"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①①"><c- b>DOMString</c-></a> <a data-readonly data-type="DOMString" href="#dom-trustedtypepolicy-name"><code><c- g>name</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑦①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑤①"><c- n>TrustedHTML</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createhtml" id="ref-for-dom-trustedtypepolicy-createhtml①"><c- g>createHTML</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①②①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createhtml-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createhtml-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑧①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript①⑤"><c- n>TrustedScript</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscript" id="ref-for-dom-trustedtypepolicy-createscript②"><c- g>createScript</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①③①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createscript-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createscript-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑨①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl①①"><c- n>TrustedScriptURL</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscripturl" id="ref-for-dom-trustedtypepolicy-createscripturl②"><c- g>createScriptURL</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①④①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createscripturl-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createscripturl-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-trustedtypepolicyoptions"><code><c- g>TrustedTypePolicyOptions</c-></code></a> {
    <a class="n" data-link-type="idl-name" href="#callbackdef-createhtmlcallback" id="ref-for-callbackdef-createhtmlcallback①"><c- n>CreateHTMLCallback</c-></a>? <a data-type="CreateHTMLCallback? " href="#dom-trustedtypepolicyoptions-createhtml"><code><c- g>createHTML</c-></code></a>;
    <a class="n" data-link-type="idl-name" href="#callbackdef-createscriptcallback" id="ref-for-callbackdef-createscriptcallback①"><c- n>CreateScriptCallback</c-></a>? <a data-type="CreateScriptCallback? " href="#dom-trustedtypepolicyoptions-createscript"><code><c- g>createScript</c-></code></a>;
-   <a class="n" data-link-type="idl-name" href="#callbackdef-createurlcallback" id="ref-for-callbackdef-createurlcallback①"><c- n>CreateURLCallback</c-></a>? <a data-type="CreateURLCallback? " href="#dom-trustedtypepolicyoptions-createurl"><code><c- g>createURL</c-></code></a>;
    <a class="n" data-link-type="idl-name" href="#callbackdef-createscripturlcallback" id="ref-for-callbackdef-createscripturlcallback①"><c- n>CreateScriptURLCallback</c-></a>? <a data-type="CreateScriptURLCallback? " href="#dom-trustedtypepolicyoptions-createscripturl"><code><c- g>createScriptURL</c-></code></a>;
 };
-<c- b>callback</c-> <a href="#callbackdef-createhtmlcallback"><code><c- g>CreateHTMLCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑥①"><c- b>DOMString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑦①"><c- b>DOMString</c-></a> <a href="#dom-createhtmlcallback-input"><code><c- g>input</c-></code></a>);
-<c- b>callback</c-> <a href="#callbackdef-createscriptcallback"><code><c- g>CreateScriptCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑧①"><c- b>DOMString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑨①"><c- b>DOMString</c-></a> <a href="#dom-createscriptcallback-input"><code><c- g>input</c-></code></a>);
-<c- b>callback</c-> <a href="#callbackdef-createurlcallback"><code><c- g>CreateURLCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④"><c- b>USVString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⓪①"><c- b>DOMString</c-></a> <a href="#dom-createurlcallback-input"><code><c- g>input</c-></code></a>);
-<c- b>callback</c-> <a href="#callbackdef-createscripturlcallback"><code><c- g>CreateScriptURLCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①"><c- b>USVString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①①"><c- b>DOMString</c-></a> <a href="#dom-createscripturlcallback-input"><code><c- g>input</c-></code></a>);
+<c- b>callback</c-> <a href="#callbackdef-createhtmlcallback"><code><c- g>CreateHTMLCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑤①"><c- b>DOMString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑥①"><c- b>DOMString</c-></a> <a href="#dom-createhtmlcallback-input"><code><c- g>input</c-></code></a>);
+<c- b>callback</c-> <a href="#callbackdef-createscriptcallback"><code><c- g>CreateScriptCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑦①"><c- b>DOMString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑧①"><c- b>DOMString</c-></a> <a href="#dom-createscriptcallback-input"><code><c- g>input</c-></code></a>);
+<c- b>callback</c-> <a href="#callbackdef-createscripturlcallback"><code><c- g>CreateScriptURLCallback</c-></code></a> = <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②"><c- b>USVString</c-></a> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑨①"><c- b>DOMString</c-></a> <a href="#dom-createscripturlcallback-input"><code><c- g>input</c-></code></a>);
 
-<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②②①"><c- b>DOMString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑦①"><c- n>TrustedHTML</c-></a>) <a href="#typedefdef-htmlstring"><code><c- g>HTMLString</c-></code></a>;
-<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②③①"><c- b>DOMString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript③①"><c- n>TrustedScript</c-></a>) <a href="#typedefdef-scriptstring"><code><c- g>ScriptString</c-></code></a>;
-<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②①"><c- b>USVString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl③①"><c- n>TrustedScriptURL</c-></a>) <a href="#typedefdef-scripturlstring"><code><c- g>ScriptURLString</c-></code></a>;
-<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③①"><c- b>USVString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl③①"><c- n>TrustedURL</c-></a>) <a href="#typedefdef-urlstring"><code><c- g>URLString</c-></code></a>;
-<c- b>typedef</c-> (<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑧①"><c- n>TrustedHTML</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript④①"><c- n>TrustedScript</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl④①"><c- n>TrustedScriptURL</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl④①"><c- n>TrustedURL</c-></a>) <a href="#typedefdef-trustedtype"><code><c- g>TrustedType</c-></code></a>;
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⓪①"><c- b>DOMString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑦①"><c- n>TrustedHTML</c-></a>) <a href="#typedefdef-htmlstring"><code><c- g>HTMLString</c-></code></a>;
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①①"><c- b>DOMString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript③①"><c- n>TrustedScript</c-></a>) <a href="#typedefdef-scriptstring"><code><c- g>ScriptString</c-></code></a>;
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①①"><c- b>USVString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl③①"><c- n>TrustedScriptURL</c-></a>) <a href="#typedefdef-scripturlstring"><code><c- g>ScriptURLString</c-></code></a>;
+<c- b>typedef</c-> (<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑧①"><c- n>TrustedHTML</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript④①"><c- n>TrustedScript</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl④①"><c- n>TrustedScriptURL</c-></a>) <a href="#typedefdef-trustedtype"><code><c- g>TrustedType</c-></code></a>;
 
-<c- b>typedef</c-> (([<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs③"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②④①"><c- b>DOMString</c-></a>) <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑨①"><c- n>TrustedHTML</c-></a>) <a href="#typedefdef-htmlstringdefaultsempty"><code><c- g>HTMLStringDefaultsEmpty</c-></code></a>;
+<c- b>typedef</c-> (([<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs②"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②②①"><c- b>DOMString</c-></a>) <c- b>or</c-> <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑨①"><c- n>TrustedHTML</c-></a>) <a href="#typedefdef-htmlstringdefaultsempty"><code><c- g>HTMLStringDefaultsEmpty</c-></code></a>;
 
 <c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window③①"><c- g>Window</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①②①"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c->
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①⓪①"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c->
       <a class="n" data-link-type="idl-name" href="#trustedtypepolicyfactory" id="ref-for-trustedtypepolicyfactory③①"><c- n>TrustedTypePolicyFactory</c-></a> <a data-readonly data-type="TrustedTypePolicyFactory" href="#dom-window-trustedtypes"><code><c- g>trustedTypes</c-></code></a>;
-
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy③"><c- n>WindowProxy</c-></a>? <a href="#dom-window-open"><code><c- g>open</c-></code></a>(
-      [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑦①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑤①"><c- n>TrustedURL</c-></a>] <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①④"><c- n>URLString</c-></a> <a href="#dom-window-open-url-target-features-url"><code><c- g>url</c-></code></a> = "about:blank",
-      <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑤①"><c- b>DOMString</c-></a> <a href="#dom-window-open-url-target-features-target"><code><c- g>target</c-></code></a> = "_blank",
-      <c- b>optional</c-> ([<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs①①"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑥①"><c- b>DOMString</c-></a>) <a href="#dom-window-open-url-target-features-features"><code><c- g>features</c-></code></a> = "");
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②①"><c- g>Document</c-></a> {
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy①①"><c- n>WindowProxy</c-></a>? <a href="#dom-document-open"><code><c- g>open</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑧①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑥①"><c- n>TrustedURL</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①③"><c- n>URLString</c-></a> <a href="#dom-document-open-url-name-features-url"><code><c- g>url</c-></code></a>, <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑦①"><c- b>DOMString</c-></a> <a href="#dom-document-open-url-name-features-name"><code><c- g>name</c-></code></a>, <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑧①"><c- b>DOMString</c-></a> <a href="#dom-document-open-url-name-features-features"><code><c- g>features</c-></code></a>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②②"><c- g>CEReactions</c-></a>] <c- b>void</c-> <a href="#dom-document-write"><code><c- g>write</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑨①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⓪①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring⑥"><c- n>HTMLString</c-></a>... <a href="#dom-document-write-text-text"><code><c- g>text</c-></code></a>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①①⓪"><c- g>CEReactions</c-></a>] <c- b>void</c-> <a href="#dom-document-writeln"><code><c- g>writeln</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⓪①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①①①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring①①"><c- n>HTMLString</c-></a>... <a href="#dom-document-writeln-text-text"><code><c- g>text</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①④"><c- g>CEReactions</c-></a>] <c- b>void</c-> <a href="#dom-document-write"><code><c- g>write</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑦①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⓪①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring⑥"><c- n>HTMLString</c-></a>... <a href="#dom-document-write-text-text"><code><c- g>text</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑤"><c- g>CEReactions</c-></a>] <c- b>void</c-> <a href="#dom-document-writeln"><code><c- g>writeln</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑧①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①①①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring①①"><c- n>HTMLString</c-></a>... <a href="#dom-document-writeln-text-text"><code><c- g>text</c-></code></a>);
 };
 
-<c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/history.html#location" id="ref-for-location①①"><c- g>Location</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①③①"><c- g>Unforgeable</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①①①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑦①"><c- n>TrustedURL</c-></a>] <a href="#Location-stringification-behavior"><c- b>stringifier</c-></a> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring②①"><c- n>URLString</c-></a> <a data-type="URLString" href="#dom-location-href"><code><c- g>href</c-></code></a>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①④①"><c- g>Unforgeable</c-></a>] <c- b>void</c-> <a href="#dom-location-assign"><code><c- g>assign</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①②①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑧①"><c- n>TrustedURL</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring③①"><c- n>URLString</c-></a> <a href="#dom-location-assign-url-url"><code><c- g>url</c-></code></a>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①⑤①"><c- g>Unforgeable</c-></a>] <c- b>void</c-> <a href="#dom-location-replace"><code><c- g>replace</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①③①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑨①"><c- n>TrustedURL</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring④①"><c- n>URLString</c-></a> <a href="#dom-location-replace-url-url"><code><c- g>url</c-></code></a>);
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement⑥"><c- g>HTMLScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement①⓪"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②③"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①④①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑤①"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring④"><c- n>ScriptURLString</c-></a> <a data-type="ScriptURLString" href="#dom-htmlscriptelement-src"><code><c- g>src</c-></code></a>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions③①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑤①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑤①"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring④"><c- n>ScriptString</c-></a> <a data-type="ScriptString" href="#dom-htmlscriptelement-text"><code><c- g>text</c-></code></a>;
+<c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement⑥"><c- g>HTMLScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑤"><c- n>HTMLElement</c-></a> {
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑨①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑤①"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring④"><c- n>ScriptURLString</c-></a> <a data-type="ScriptURLString" href="#dom-htmlscriptelement-src"><code><c- g>src</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions③①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⓪①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑤①"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring④"><c- n>ScriptString</c-></a> <a data-type="ScriptString" href="#dom-htmlscriptelement-text"><code><c- g>text</c-></code></a>;
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement" id="ref-for-htmliframeelement①"><c- g>HTMLIFrameElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement①①"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions④①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑥①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⓪①"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑤①"><c- n>URLString</c-></a> <a data-type="URLString" href="#dom-htmliframeelement-src"><code><c- g>src</c-></code></a>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑤①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑦①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①②①"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring②①"><c- n>HTMLString</c-></a> <a data-type="HTMLString" href="#dom-htmliframeelement-srcdoc"><code><c- g>srcdoc</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions④①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①①①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①②①"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring②①"><c- n>HTMLString</c-></a> <a data-type="HTMLString" href="#dom-htmliframeelement-srcdoc"><code><c- g>srcdoc</c-></code></a>;
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement" id="ref-for-htmlembedelement①"><c- g>HTMLEmbedElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement②①"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑥①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑧①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑥①"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring①①"><c- n>ScriptURLString</c-></a> <a data-type="ScriptURLString" href="#dom-htmlembedelement-src"><code><c- g>src</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑤①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①②①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑥①"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring①①"><c- n>ScriptURLString</c-></a> <a data-type="ScriptURLString" href="#dom-htmlembedelement-src"><code><c- g>src</c-></code></a>;
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement" id="ref-for-htmlobjectelement①"><c- g>HTMLObjectElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement③①"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑦①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑨①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑦①"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring②①"><c- n>ScriptURLString</c-></a> <a data-type="ScriptURLString" href="#dom-htmlobjectelement-data"><code><c- g>data</c-></code></a>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑧①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⓪①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑧①"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑨①"><c- b>DOMString</c-></a> <a data-type="DOMString" href="#dom-htmlobjectelement-codebase"><code><c- g>codeBase</c-></code></a>; // obsolete
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/obsolete.html#htmlframeelement" id="ref-for-htmlframeelement①"><c- g>HTMLFrameElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement④①"><c- n>HTMLElement</c-></a> { // obsolete
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑨①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②①①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①①①"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑥①"><c- n>URLString</c-></a> <a data-type="URLString" href="#dom-htmlframeelement-src"><code><c- g>src</c-></code></a>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement" id="ref-for-htmlformelement①"><c- g>HTMLFormElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑤①"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⓪①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②②①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①②①"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑦①"><c- n>URLString</c-></a> <a data-type="URLString" href="#dom-htmlformelement-action"><code><c- g>action</c-></code></a>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement" id="ref-for-htmlinputelement①"><c- g>HTMLInputElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑥①"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①①①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②③①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①③①"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑧①"><c- n>URLString</c-></a> <a data-type="URLString" href="#dom-htmlinputelement-formaction"><code><c- g>formAction</c-></code></a>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①②①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②④①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①④①"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring⑨①"><c- n>URLString</c-></a> <a data-type="URLString" href="#dom-htmlinputelement-src"><code><c- g>src</c-></code></a>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement" id="ref-for-htmlbuttonelement①"><c- g>HTMLButtonElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑦①"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①③①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⑤①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑤①"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①⓪①"><c- n>URLString</c-></a> <a data-type="URLString" href="#dom-htmlbuttonelement-formaction"><code><c- g>formAction</c-></code></a>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils" id="ref-for-htmlhyperlinkelementutils①"><c- g>HTMLHyperlinkElementUtils</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①④①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⑥①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑥①"><c- n>TrustedURL</c-></a>] <a href="#HTMLHyperlinkElementUtils-stringification-behavior"><c- b>stringifier</c-></a> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①①①"><c- n>URLString</c-></a> <a data-type="URLString" href="#dom-htmlhyperlinkelementutils-href"><code><c- g>href</c-></code></a>;
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmlbaseelement" id="ref-for-htmlbaseelement①"><c- g>HTMLBaseElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑧①"><c- n>HTMLElement</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑤①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⑦①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑦①"><c- n>TrustedURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①②①"><c- n>URLString</c-></a> <a data-type="URLString" href="#dom-htmlbaseelement-href"><code><c- g>href</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑥①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①③①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑦①"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring②①"><c- n>ScriptURLString</c-></a> <a data-type="ScriptURLString" href="#dom-htmlobjectelement-data"><code><c- g>data</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑦①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①④①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑧①"><c- n>TrustedScriptURL</c-></a>] <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②③①"><c- b>DOMString</c-></a> <a data-type="DOMString" href="#dom-htmlobjectelement-codebase"><code><c- g>codeBase</c-></code></a>; // obsolete
 };
 
 // TODO: Add HTMLPortalElement.src from https://github.com/WICG/portals once it’s specced.
 
-<c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement③①"><c- g>HTMLScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement⑨①"><c- n>HTMLElement</c-></a> {
- [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑥①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⑨①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑥①"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs②①"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring①①"><c- n>ScriptString</c-></a> <a data-type="[TreatNullAs=EmptyString] ScriptString" href="#dom-htmlscriptelement-innertext"><code><c- g>innerText</c-></code></a>;
- [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑦①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③⓪①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑦①"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring②①"><c- n>ScriptString</c-></a>? <a data-type="ScriptString?" href="#dom-htmlscriptelement-textcontent"><code><c- g>textContent</c-></code></a>;
+<c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement③①"><c- g>HTMLScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement④①"><c- n>HTMLElement</c-></a> {
+ [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑧①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑥①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑥①"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs①①"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring①①"><c- n>ScriptString</c-></a> <a data-type="[TreatNullAs=EmptyString] ScriptString" href="#dom-htmlscriptelement-innertext"><code><c- g>innerText</c-></code></a>;
+ [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions⑨①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑦①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript⑦①"><c- n>TrustedScript</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring②①"><c- n>ScriptString</c-></a>? <a data-type="ScriptString?" href="#dom-htmlscriptelement-textcontent"><code><c- g>textContent</c-></code></a>;
 };
 
 <c- b>typedef</c-> (<a class="n" data-link-type="idl-name" href="#typedefdef-scriptstring" id="ref-for-typedefdef-scriptstring③①"><c- n>ScriptString</c-></a> <c- b>or</c-> <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#Function" id="ref-for-Function③"><c- n>Function</c-></a>) <a href="#typedefdef-trustedtimerhandler"><code><c- g>TrustedTimerHandler</c-></code></a>;
@@ -4120,31 +3865,27 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long②①"><c- b>long</c-></a> <a href="#dom-windoworworkerglobalscope-setinterval"><code><c- g>setInterval</c-></code></a>(<a class="n" data-link-type="idl-name" href="#typedefdef-trustedtimerhandler" id="ref-for-typedefdef-trustedtimerhandler①①"><c- n>TrustedTimerHandler</c-></a> <a href="#dom-windoworworkerglobalscope-setinterval-handler-timeout-arguments-handler"><code><c- g>handler</c-></code></a>, <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long③①"><c- b>long</c-></a> <a href="#dom-windoworworkerglobalscope-setinterval-handler-timeout-arguments-timeout"><code><c- g>timeout</c-></code></a> = 0, <c- b>any</c->... <a href="#dom-windoworworkerglobalscope-setinterval-handler-timeout-arguments-arguments"><code><c- g>arguments</c-></code></a>);
 };
 
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGURIReference" id="ref-for-InterfaceSVGURIReference①①"><c- g>SVGURIReference</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject" id="ref-for-SameObject①"><c- g>SameObject</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③①①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑧①"><c- n>TrustedURL</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString" id="ref-for-InterfaceSVGAnimatedString①"><c- n>SVGAnimatedString</c-></a> <a data-readonly data-type="SVGAnimatedString" href="#dom-svgurireference-href"><code><c- g>href</c-></code></a>;
-};
-
 <c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface" href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement" id="ref-for-InterfaceSVGScriptElement①①"><c- g>SVGScriptElement</c-></a> : <a class="n" data-link-type="idl-name" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement" id="ref-for-InterfaceSVGElement①"><c- n>SVGElement</c-></a> {
  // overwrites the definition in SVGURIReference.
- [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③②①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑨①"><c- n>TrustedScriptURL</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring③①"><c- n>ScriptURLString</c-></a> <a data-readonly data-type="ScriptURLString" href="#dom-svgscriptelement-href"><code><c- g>href</c-></code></a>;
+ [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑧①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl⑨①"><c- n>TrustedScriptURL</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-scripturlstring" id="ref-for-typedefdef-scripturlstring③①"><c- n>ScriptURLString</c-></a> <a data-readonly data-type="ScriptURLString" href="#dom-svgscriptelement-href"><code><c- g>href</c-></code></a>;
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②①"><c- g>Element</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑧①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③③①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①③①"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstringdefaultsempty" id="ref-for-typedefdef-htmlstringdefaultsempty①①"><c- n>HTMLStringDefaultsEmpty</c-></a> <a data-type="HTMLStringDefaultsEmpty" href="#dom-element-outerhtml"><code><c- g>outerHTML</c-></code></a>;
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⑨①"><c- g>CEReactions</c-></a>] <c- b>void</c-> <a href="#dom-element-insertadjacenthtml"><code><c- g>insertAdjacentHTML</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③⓪①"><c- b>DOMString</c-></a> <a href="#dom-element-insertadjacenthtml-position-text-position"><code><c- g>position</c-></code></a>, [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③④①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①④①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring③①"><c- n>HTMLString</c-></a> <a href="#dom-element-insertadjacenthtml-position-text-text"><code><c- g>text</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①⓪①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes①⑨①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①③①"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstringdefaultsempty" id="ref-for-typedefdef-htmlstringdefaultsempty①①"><c- n>HTMLStringDefaultsEmpty</c-></a> <a data-type="HTMLStringDefaultsEmpty" href="#dom-element-outerhtml"><code><c- g>outerHTML</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①①①"><c- g>CEReactions</c-></a>] <c- b>void</c-> <a href="#dom-element-insertadjacenthtml"><code><c- g>insertAdjacentHTML</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②④①"><c- b>DOMString</c-></a> <a href="#dom-element-insertadjacenthtml-position-text-position"><code><c- g>position</c-></code></a>, [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②⓪①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①④①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring③①"><c- n>HTMLString</c-></a> <a href="#dom-element-insertadjacenthtml-position-text-text"><code><c- g>text</c-></code></a>);
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <c- b>mixin</c-> <a class="idl-code" data-link-type="interface"><c- g>InnerHTML</c-></a> { // specified in a draft version at https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②⓪①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③⑤①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑤①"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstringdefaultsempty" id="ref-for-typedefdef-htmlstringdefaultsempty②①"><c- n>HTMLStringDefaultsEmpty</c-></a> <a data-type="HTMLStringDefaultsEmpty" href="#dom-innerhtml-innerhtml"><code><c- g>innerHTML</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①②①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②①①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑤①"><c- n>TrustedHTML</c-></a>] <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstringdefaultsempty" id="ref-for-typedefdef-htmlstringdefaultsempty②①"><c- n>HTMLStringDefaultsEmpty</c-></a> <a data-type="HTMLStringDefaultsEmpty" href="#dom-innerhtml-innerhtml"><code><c- g>innerHTML</c-></code></a>;
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①"><c- g>Range</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②①①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject②"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment①"><c- n>DocumentFragment</c-></a> <a href="#dom-range-createcontextualfragment"><code><c- g>createContextualFragment</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③⑥①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑥①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring④①"><c- n>HTMLString</c-></a> <a href="#dom-range-createcontextualfragment-fragment-fragment"><code><c- g>fragment</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①③①"><c- g>CEReactions</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject②"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment①"><c- n>DocumentFragment</c-></a> <a href="#dom-range-createcontextualfragment"><code><c- g>createContextualFragment</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②②①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑥①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring④①"><c- n>HTMLString</c-></a> <a href="#dom-range-createcontextualfragment-fragment-fragment"><code><c- g>fragment</c-></code></a>);
 };
 
-[<a href="#dom-domparser-domparser"><code><c- g>Constructor</c-></code></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+[<a href="#dom-domparser-domparser"><code><c- g>Constructor</c-></code></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#domparser"><code><c- g>DOMParser</c-></code></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①①"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③①"><c- n>Document</c-></a> <a href="#dom-domparser-parsefromstring"><code><c- g>parseFromString</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes③⑦①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑦①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring⑤①"><c- n>HTMLString</c-></a> <a href="#dom-domparser-parsefromstring-str-type-str"><code><c- g>str</c-></code></a>, <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/DOM-Parsing/#h-the-domparser-interface" id="ref-for-h-the-domparser-interface①"><c- n>SupportedType</c-></a> <a href="#dom-domparser-parsefromstring-str-type-type"><code><c- g>type</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①①"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③①"><c- n>Document</c-></a> <a href="#dom-domparser-parsefromstring"><code><c- g>parseFromString</c-></code></a>([<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes②③①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml①⑦①"><c- n>TrustedHTML</c-></a>] <a class="n" data-link-type="idl-name" href="#typedefdef-htmlstring" id="ref-for-typedefdef-htmlstring⑤①"><c- n>HTMLString</c-></a> <a href="#dom-domparser-parsefromstring-str-type-str"><code><c- g>str</c-></code></a>, <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/DOM-Parsing/#h-the-domparser-interface" id="ref-for-h-the-domparser-interface①"><c- n>SupportedType</c-></a> <a href="#dom-domparser-parsefromstring-str-type-type"><code><c- g>type</c-></code></a>);
 };
 
 </pre>
@@ -4159,6 +3900,7 @@ For some sinks a <code>null</code> value will result in "", and "null" for other
 This already caused problems in the polyfill. <a href="https://github.com/WICG/trusted-types/issues/2">&lt;https://github.com/WICG/trusted-types/issues/2></a><a href="#issue-52d7d8d6"> ↵ </a></div>
    <div class="issue"> Define for workers.<a href="#issue-a5679137"> ↵ </a></div>
    <div class="issue"> Remove the note when the API in Chrome is shipped.<a href="#issue-3d9ee9e6"> ↵ </a></div>
+   <div class="issue"> Add base.href enforcement.<a href="#issue-13577559"> ↵ </a></div>
    <div class="issue"> This depends on a solution to <a href="https://github.com/WICG/trusted-types/issues/144">issue #144</a> like <a href="https://github.com/tc39-transfer/dynamic-code-brand-checks#problem-host-callout-does-not-receive-type-information">TC39 HostBeforeCompile</a><a href="#issue-e28ea232"> ↵ </a></div>
    <div class="issue"> In some cases, the violation "<code>'report-sample'</code>" contain the result of
 applying the default policy to a string argument which differs.
@@ -4178,15 +3920,14 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-injection-sink③">2.2.1. TrustedHTML</a>
     <li><a href="#ref-for-injection-sink④">2.2.2. TrustedScript</a>
     <li><a href="#ref-for-injection-sink⑤">2.2.3. TrustedScriptURL</a>
-    <li><a href="#ref-for-injection-sink⑥">2.2.4. TrustedURL</a>
-    <li><a href="#ref-for-injection-sink⑦">2.3. Policies</a> <a href="#ref-for-injection-sink⑧">(2)</a>
-    <li><a href="#ref-for-injection-sink⑨">2.3.4. Default policy</a>
-    <li><a href="#ref-for-injection-sink①⓪">2.4. Enforcement</a> <a href="#ref-for-injection-sink①①">(2)</a>
-    <li><a href="#ref-for-injection-sink①②">2.4.2. TrustedTypes extended attribute</a>
-    <li><a href="#ref-for-injection-sink①③">3.4. Get Trusted Type compliant string</a>
-    <li><a href="#ref-for-injection-sink①④">4.5.1. trusted-types directive</a> <a href="#ref-for-injection-sink①⑤">(2)</a> <a href="#ref-for-injection-sink①⑥">(3)</a> <a href="#ref-for-injection-sink①⑦">(4)</a>
-    <li><a href="#ref-for-injection-sink①⑧">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
-    <li><a href="#ref-for-injection-sink①⑨">6.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-injection-sink⑥">2.3. Policies</a> <a href="#ref-for-injection-sink⑦">(2)</a>
+    <li><a href="#ref-for-injection-sink⑧">2.3.4. Default policy</a>
+    <li><a href="#ref-for-injection-sink⑨">2.4. Enforcement</a> <a href="#ref-for-injection-sink①⓪">(2)</a>
+    <li><a href="#ref-for-injection-sink①①">2.4.2. TrustedTypes extended attribute</a>
+    <li><a href="#ref-for-injection-sink①②">3.4. Get Trusted Type compliant string</a>
+    <li><a href="#ref-for-injection-sink①③">4.5.1. trusted-types directive</a> <a href="#ref-for-injection-sink①④">(2)</a> <a href="#ref-for-injection-sink①⑤">(3)</a> <a href="#ref-for-injection-sink①⑥">(4)</a>
+    <li><a href="#ref-for-injection-sink①⑦">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
+    <li><a href="#ref-for-injection-sink①⑧">6.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="trusted-type">
@@ -4209,7 +3950,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-trustedhtml⑥">2.4.2. TrustedTypes extended attribute</a>
     <li><a href="#ref-for-trustedhtml⑦">4. Integrations</a> <a href="#ref-for-trustedhtml⑧">(2)</a> <a href="#ref-for-trustedhtml⑨">(3)</a>
     <li><a href="#ref-for-trustedhtml①⓪">4.1.2. Extensions to the Document interface</a> <a href="#ref-for-trustedhtml①①">(2)</a>
-    <li><a href="#ref-for-trustedhtml①②">4.1.4. Enforcement in element attributes</a>
+    <li><a href="#ref-for-trustedhtml①②">4.1.3. Enforcement in element attributes</a>
     <li><a href="#ref-for-trustedhtml①③">4.4. Integration with DOM Parsing</a> <a href="#ref-for-trustedhtml①④">(2)</a> <a href="#ref-for-trustedhtml①⑤">(3)</a> <a href="#ref-for-trustedhtml①⑥">(4)</a> <a href="#ref-for-trustedhtml①⑦">(5)</a>
    </ul>
   </aside>
@@ -4220,10 +3961,10 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-trustedscript①">2.3.2. TrustedTypePolicy</a>
     <li><a href="#ref-for-trustedscript②">2.4.2. TrustedTypes extended attribute</a>
     <li><a href="#ref-for-trustedscript③">4. Integrations</a> <a href="#ref-for-trustedscript④">(2)</a>
-    <li><a href="#ref-for-trustedscript⑤">4.1.4. Enforcement in element attributes</a>
-    <li><a href="#ref-for-trustedscript⑥">4.1.5. Enforcement for script text contents</a> <a href="#ref-for-trustedscript⑦">(2)</a> <a href="#ref-for-trustedscript⑧">(3)</a>
-    <li><a href="#ref-for-trustedscript⑨">4.1.6. Enforcement in timer functions</a> <a href="#ref-for-trustedscript①⓪">(2)</a>
-    <li><a href="#ref-for-trustedscript①①">4.1.7. Enforcement in event handler content attributes</a>
+    <li><a href="#ref-for-trustedscript⑤">4.1.3. Enforcement in element attributes</a>
+    <li><a href="#ref-for-trustedscript⑥">4.1.4. Enforcement for script text contents</a> <a href="#ref-for-trustedscript⑦">(2)</a> <a href="#ref-for-trustedscript⑧">(3)</a>
+    <li><a href="#ref-for-trustedscript⑨">4.1.5. Enforcement in timer functions</a> <a href="#ref-for-trustedscript①⓪">(2)</a>
+    <li><a href="#ref-for-trustedscript①①">4.1.6. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-trustedscript①②">4.2. Integration with SVG</a>
     <li><a href="#ref-for-trustedscript①③">4.5.1.1. trusted-types Pre-Navigation check</a>
     <li><a href="#ref-for-trustedscript①④">4.5.5. 'trusted-script' keyword</a>
@@ -4236,22 +3977,8 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-trustedscripturl①">2.3.2. TrustedTypePolicy</a>
     <li><a href="#ref-for-trustedscripturl②">2.4.2. TrustedTypes extended attribute</a>
     <li><a href="#ref-for-trustedscripturl③">4. Integrations</a> <a href="#ref-for-trustedscripturl④">(2)</a>
-    <li><a href="#ref-for-trustedscripturl⑤">4.1.4. Enforcement in element attributes</a> <a href="#ref-for-trustedscripturl⑥">(2)</a> <a href="#ref-for-trustedscripturl⑦">(3)</a> <a href="#ref-for-trustedscripturl⑧">(4)</a>
+    <li><a href="#ref-for-trustedscripturl⑤">4.1.3. Enforcement in element attributes</a> <a href="#ref-for-trustedscripturl⑥">(2)</a> <a href="#ref-for-trustedscripturl⑦">(3)</a> <a href="#ref-for-trustedscripturl⑧">(4)</a>
     <li><a href="#ref-for-trustedscripturl⑨">4.2. Integration with SVG</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="trustedurl">
-   <b><a href="#trustedurl">#trustedurl</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-trustedurl">2.3.1. TrustedTypePolicyFactory</a>
-    <li><a href="#ref-for-trustedurl①">2.3.2. TrustedTypePolicy</a>
-    <li><a href="#ref-for-trustedurl②">2.4.2. TrustedTypes extended attribute</a>
-    <li><a href="#ref-for-trustedurl③">4. Integrations</a> <a href="#ref-for-trustedurl④">(2)</a>
-    <li><a href="#ref-for-trustedurl⑤">4.1.1. Extensions to the Window interface</a>
-    <li><a href="#ref-for-trustedurl⑥">4.1.2. Extensions to the Document interface</a>
-    <li><a href="#ref-for-trustedurl⑦">4.1.3. Extensions to the Location interface</a> <a href="#ref-for-trustedurl⑧">(2)</a> <a href="#ref-for-trustedurl⑨">(3)</a>
-    <li><a href="#ref-for-trustedurl①⓪">4.1.4. Enforcement in element attributes</a> <a href="#ref-for-trustedurl①①">(2)</a> <a href="#ref-for-trustedurl①②">(3)</a> <a href="#ref-for-trustedurl①③">(4)</a> <a href="#ref-for-trustedurl①④">(5)</a> <a href="#ref-for-trustedurl①⑤">(6)</a> <a href="#ref-for-trustedurl①⑥">(7)</a> <a href="#ref-for-trustedurl①⑦">(8)</a>
-    <li><a href="#ref-for-trustedurl①⑧">4.2. Integration with SVG</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="trustedtypepolicyfactory">
@@ -4294,12 +4021,6 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-isscripturl">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-isurl">
-   <b><a href="#dom-trustedtypepolicyfactory-isurl">#dom-trustedtypepolicyfactory-isurl</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-trustedtypepolicyfactory-isurl">2.3.1. TrustedTypePolicyFactory</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-getpropertytype">
    <b><a href="#dom-trustedtypepolicyfactory-getpropertytype">#dom-trustedtypepolicyfactory-getpropertytype</a></b><b>Referenced in:</b>
    <ul>
@@ -4330,11 +4051,10 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-trustedtypepolicy">2.2.1. TrustedHTML</a>
     <li><a href="#ref-for-trustedtypepolicy①">2.2.2. TrustedScript</a>
     <li><a href="#ref-for-trustedtypepolicy②">2.2.3. TrustedScriptURL</a>
-    <li><a href="#ref-for-trustedtypepolicy③">2.2.4. TrustedURL</a>
-    <li><a href="#ref-for-trustedtypepolicy④">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-trustedtypepolicy⑤">(2)</a> <a href="#ref-for-trustedtypepolicy⑥">(3)</a> <a href="#ref-for-trustedtypepolicy⑦">(4)</a> <a href="#ref-for-trustedtypepolicy⑧">(5)</a>
-    <li><a href="#ref-for-trustedtypepolicy⑨">2.3.3. TrustedTypePolicyOptions</a>
-    <li><a href="#ref-for-trustedtypepolicy①⓪">3.1. Create a Trusted Type Policy</a> <a href="#ref-for-trustedtypepolicy①①">(2)</a>
-    <li><a href="#ref-for-trustedtypepolicy①②">3.3. Create a Trusted Type</a>
+    <li><a href="#ref-for-trustedtypepolicy③">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-trustedtypepolicy④">(2)</a> <a href="#ref-for-trustedtypepolicy⑤">(3)</a> <a href="#ref-for-trustedtypepolicy⑥">(4)</a> <a href="#ref-for-trustedtypepolicy⑦">(5)</a>
+    <li><a href="#ref-for-trustedtypepolicy⑧">2.3.3. TrustedTypePolicyOptions</a>
+    <li><a href="#ref-for-trustedtypepolicy⑨">3.1. Create a Trusted Type Policy</a> <a href="#ref-for-trustedtypepolicy①⓪">(2)</a>
+    <li><a href="#ref-for-trustedtypepolicy①①">3.3. Create a Trusted Type</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="trustedtypepolicy-name">
@@ -4363,13 +4083,6 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-dom-trustedtypepolicy-createscripturl①">3.1. Create a Trusted Type Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicy-createurl">
-   <b><a href="#dom-trustedtypepolicy-createurl">#dom-trustedtypepolicy-createurl</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-trustedtypepolicy-createurl">2.3.2. TrustedTypePolicy</a>
-    <li><a href="#ref-for-dom-trustedtypepolicy-createurl①">3.1. Create a Trusted Type Policy</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dictdef-trustedtypepolicyoptions">
    <b><a href="#dictdef-trustedtypepolicyoptions">#dictdef-trustedtypepolicyoptions</a></b><b>Referenced in:</b>
    <ul>
@@ -4390,12 +4103,6 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-dom-trustedtypepolicyoptions-createscript">3.1. Create a Trusted Type Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyoptions-createurl">
-   <b><a href="#dom-trustedtypepolicyoptions-createurl">#dom-trustedtypepolicyoptions-createurl</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-trustedtypepolicyoptions-createurl">3.1. Create a Trusted Type Policy</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="dom-trustedtypepolicyoptions-createscripturl">
    <b><a href="#dom-trustedtypepolicyoptions-createscripturl">#dom-trustedtypepolicyoptions-createscripturl</a></b><b>Referenced in:</b>
    <ul>
@@ -4412,12 +4119,6 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
    <b><a href="#callbackdef-createscriptcallback">#callbackdef-createscriptcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-createscriptcallback">2.3.3. TrustedTypePolicyOptions</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="callbackdef-createurlcallback">
-   <b><a href="#callbackdef-createurlcallback">#callbackdef-createurlcallback</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-callbackdef-createurlcallback">2.3.3. TrustedTypePolicyOptions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="callbackdef-createscripturlcallback">
@@ -4450,13 +4151,11 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-extendedattrdef-trustedtypes">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-extendedattrdef-trustedtypes①">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes②">(3)</a> <a href="#ref-for-extendedattrdef-trustedtypes③">(4)</a>
     <li><a href="#ref-for-extendedattrdef-trustedtypes④">2.4.2. TrustedTypes extended attribute</a> <a href="#ref-for-extendedattrdef-trustedtypes⑤">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes⑥">(3)</a>
-    <li><a href="#ref-for-extendedattrdef-trustedtypes⑦">4.1.1. Extensions to the Window interface</a>
-    <li><a href="#ref-for-extendedattrdef-trustedtypes⑧">4.1.2. Extensions to the Document interface</a> <a href="#ref-for-extendedattrdef-trustedtypes⑨">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes①⓪">(3)</a>
-    <li><a href="#ref-for-extendedattrdef-trustedtypes①①">4.1.3. Extensions to the Location interface</a> <a href="#ref-for-extendedattrdef-trustedtypes①②">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes①③">(3)</a>
-    <li><a href="#ref-for-extendedattrdef-trustedtypes①④">4.1.4. Enforcement in element attributes</a> <a href="#ref-for-extendedattrdef-trustedtypes①⑤">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes①⑥">(3)</a> <a href="#ref-for-extendedattrdef-trustedtypes①⑦">(4)</a> <a href="#ref-for-extendedattrdef-trustedtypes①⑧">(5)</a> <a href="#ref-for-extendedattrdef-trustedtypes①⑨">(6)</a> <a href="#ref-for-extendedattrdef-trustedtypes②⓪">(7)</a> <a href="#ref-for-extendedattrdef-trustedtypes②①">(8)</a> <a href="#ref-for-extendedattrdef-trustedtypes②②">(9)</a> <a href="#ref-for-extendedattrdef-trustedtypes②③">(10)</a> <a href="#ref-for-extendedattrdef-trustedtypes②④">(11)</a> <a href="#ref-for-extendedattrdef-trustedtypes②⑤">(12)</a> <a href="#ref-for-extendedattrdef-trustedtypes②⑥">(13)</a> <a href="#ref-for-extendedattrdef-trustedtypes②⑦">(14)</a>
-    <li><a href="#ref-for-extendedattrdef-trustedtypes②⑧">4.1.5. Enforcement for script text contents</a> <a href="#ref-for-extendedattrdef-trustedtypes②⑨">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes③⓪">(3)</a>
-    <li><a href="#ref-for-extendedattrdef-trustedtypes③①">4.2. Integration with SVG</a> <a href="#ref-for-extendedattrdef-trustedtypes③②">(2)</a>
-    <li><a href="#ref-for-extendedattrdef-trustedtypes③③">4.4. Integration with DOM Parsing</a> <a href="#ref-for-extendedattrdef-trustedtypes③④">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes③⑤">(3)</a> <a href="#ref-for-extendedattrdef-trustedtypes③⑥">(4)</a> <a href="#ref-for-extendedattrdef-trustedtypes③⑦">(5)</a>
+    <li><a href="#ref-for-extendedattrdef-trustedtypes⑦">4.1.2. Extensions to the Document interface</a> <a href="#ref-for-extendedattrdef-trustedtypes⑧">(2)</a>
+    <li><a href="#ref-for-extendedattrdef-trustedtypes⑨">4.1.3. Enforcement in element attributes</a> <a href="#ref-for-extendedattrdef-trustedtypes①⓪">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes①①">(3)</a> <a href="#ref-for-extendedattrdef-trustedtypes①②">(4)</a> <a href="#ref-for-extendedattrdef-trustedtypes①③">(5)</a> <a href="#ref-for-extendedattrdef-trustedtypes①④">(6)</a>
+    <li><a href="#ref-for-extendedattrdef-trustedtypes①⑤">4.1.4. Enforcement for script text contents</a> <a href="#ref-for-extendedattrdef-trustedtypes①⑥">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes①⑦">(3)</a>
+    <li><a href="#ref-for-extendedattrdef-trustedtypes①⑧">4.2. Integration with SVG</a>
+    <li><a href="#ref-for-extendedattrdef-trustedtypes①⑨">4.4. Integration with DOM Parsing</a> <a href="#ref-for-extendedattrdef-trustedtypes②⓪">(2)</a> <a href="#ref-for-extendedattrdef-trustedtypes②①">(3)</a> <a href="#ref-for-extendedattrdef-trustedtypes②②">(4)</a> <a href="#ref-for-extendedattrdef-trustedtypes②③">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-create-a-trusted-type-policy">
@@ -4475,18 +4174,18 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
   <aside class="dfn-panel" data-for="abstract-opdef-create-a-trusted-type">
    <b><a href="#abstract-opdef-create-a-trusted-type">#abstract-opdef-create-a-trusted-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-create-a-trusted-type">2.3.2. TrustedTypePolicy</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type①">(2)</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type②">(3)</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type③">(4)</a>
-    <li><a href="#ref-for-abstract-opdef-create-a-trusted-type④">3.4. Get Trusted Type compliant string</a>
-    <li><a href="#ref-for-abstract-opdef-create-a-trusted-type⑤">4.5.1.1. trusted-types Pre-Navigation check</a>
+    <li><a href="#ref-for-abstract-opdef-create-a-trusted-type">2.3.2. TrustedTypePolicy</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type①">(2)</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type②">(3)</a>
+    <li><a href="#ref-for-abstract-opdef-create-a-trusted-type③">3.4. Get Trusted Type compliant string</a>
+    <li><a href="#ref-for-abstract-opdef-create-a-trusted-type④">4.5.1.1. trusted-types Pre-Navigation check</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-get-trusted-type-compliant-string">
    <b><a href="#abstract-opdef-get-trusted-type-compliant-string">#abstract-opdef-get-trusted-type-compliant-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string">2.4.2. TrustedTypes extended attribute</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string①">(2)</a>
-    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string②">4.1.5. Enforcement for script text contents</a>
-    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string③">4.1.6. Enforcement in timer functions</a>
-    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string④">4.1.7. Enforcement in event handler content attributes</a>
+    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string②">4.1.4. Enforcement for script text contents</a>
+    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string③">4.1.5. Enforcement in timer functions</a>
+    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string④">4.1.6. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑤">4.2. Integration with SVG</a>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑥">4.5.5. 'trusted-script' keyword</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑦">(2)</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑧">(3)</a>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑨">4.5.6. IsSourceExempt Algorithm</a>
@@ -4496,39 +4195,30 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
    <b><a href="#typedefdef-htmlstring">#typedefdef-htmlstring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-htmlstring">4.1.2. Extensions to the Document interface</a> <a href="#ref-for-typedefdef-htmlstring①">(2)</a>
-    <li><a href="#ref-for-typedefdef-htmlstring②">4.1.4. Enforcement in element attributes</a>
+    <li><a href="#ref-for-typedefdef-htmlstring②">4.1.3. Enforcement in element attributes</a>
     <li><a href="#ref-for-typedefdef-htmlstring③">4.4. Integration with DOM Parsing</a> <a href="#ref-for-typedefdef-htmlstring④">(2)</a> <a href="#ref-for-typedefdef-htmlstring⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-scriptstring">
    <b><a href="#typedefdef-scriptstring">#typedefdef-scriptstring</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-typedefdef-scriptstring">4.1.4. Enforcement in element attributes</a>
-    <li><a href="#ref-for-typedefdef-scriptstring①">4.1.5. Enforcement for script text contents</a> <a href="#ref-for-typedefdef-scriptstring②">(2)</a>
-    <li><a href="#ref-for-typedefdef-scriptstring③">4.1.6. Enforcement in timer functions</a>
+    <li><a href="#ref-for-typedefdef-scriptstring">4.1.3. Enforcement in element attributes</a>
+    <li><a href="#ref-for-typedefdef-scriptstring①">4.1.4. Enforcement for script text contents</a> <a href="#ref-for-typedefdef-scriptstring②">(2)</a>
+    <li><a href="#ref-for-typedefdef-scriptstring③">4.1.5. Enforcement in timer functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-scripturlstring">
    <b><a href="#typedefdef-scripturlstring">#typedefdef-scripturlstring</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-typedefdef-scripturlstring">4.1.4. Enforcement in element attributes</a> <a href="#ref-for-typedefdef-scripturlstring①">(2)</a> <a href="#ref-for-typedefdef-scripturlstring②">(3)</a>
+    <li><a href="#ref-for-typedefdef-scripturlstring">4.1.3. Enforcement in element attributes</a> <a href="#ref-for-typedefdef-scripturlstring①">(2)</a> <a href="#ref-for-typedefdef-scripturlstring②">(3)</a>
     <li><a href="#ref-for-typedefdef-scripturlstring③">4.2. Integration with SVG</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="typedefdef-urlstring">
-   <b><a href="#typedefdef-urlstring">#typedefdef-urlstring</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-typedefdef-urlstring">4.1.1. Extensions to the Window interface</a>
-    <li><a href="#ref-for-typedefdef-urlstring①">4.1.2. Extensions to the Document interface</a>
-    <li><a href="#ref-for-typedefdef-urlstring②">4.1.3. Extensions to the Location interface</a> <a href="#ref-for-typedefdef-urlstring③">(2)</a> <a href="#ref-for-typedefdef-urlstring④">(3)</a>
-    <li><a href="#ref-for-typedefdef-urlstring⑤">4.1.4. Enforcement in element attributes</a> <a href="#ref-for-typedefdef-urlstring⑥">(2)</a> <a href="#ref-for-typedefdef-urlstring⑦">(3)</a> <a href="#ref-for-typedefdef-urlstring⑧">(4)</a> <a href="#ref-for-typedefdef-urlstring⑨">(5)</a> <a href="#ref-for-typedefdef-urlstring①⓪">(6)</a> <a href="#ref-for-typedefdef-urlstring①①">(7)</a> <a href="#ref-for-typedefdef-urlstring①②">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-trustedtype">
    <b><a href="#typedefdef-trustedtype">#typedefdef-trustedtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-trustedtype">3.4. Get Trusted Type compliant string</a> <a href="#ref-for-typedefdef-trustedtype①">(2)</a>
-    <li><a href="#ref-for-typedefdef-trustedtype②">4.1.6. Enforcement in timer functions</a>
+    <li><a href="#ref-for-typedefdef-trustedtype②">4.1.5. Enforcement in timer functions</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-htmlstringdefaultsempty">
@@ -4568,13 +4258,13 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
   <aside class="dfn-panel" data-for="typedefdef-trustedtimerhandler">
    <b><a href="#typedefdef-trustedtimerhandler">#typedefdef-trustedtimerhandler</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-typedefdef-trustedtimerhandler">4.1.6. Enforcement in timer functions</a> <a href="#ref-for-typedefdef-trustedtimerhandler①">(2)</a>
+    <li><a href="#ref-for-typedefdef-trustedtimerhandler">4.1.5. Enforcement in timer functions</a> <a href="#ref-for-typedefdef-trustedtimerhandler①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-insert-text-node-validation-steps">
    <b><a href="#abstract-opdef-insert-text-node-validation-steps">#abstract-opdef-insert-text-node-validation-steps</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-insert-text-node-validation-steps">4.1.5. Enforcement for script text contents</a>
+    <li><a href="#ref-for-abstract-opdef-insert-text-node-validation-steps">4.1.4. Enforcement for script text contents</a>
     <li><a href="#ref-for-abstract-opdef-insert-text-node-validation-steps①">4.2. Integration with SVG</a>
     <li><a href="#ref-for-abstract-opdef-insert-text-node-validation-steps②">4.3.1. Text node validation steps</a>
    </ul>

--- a/dist/spec/index.html
+++ b/dist/spec/index.html
@@ -1570,7 +1570,12 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#should-block-sink-type-mismatch"><span class="secno">4.5.2</span> <span class="content"><span>Should sink type mismatch violation be blocked by Content Security Policy?</span></span></a>
         <li><a href="#should-block-create-policy"><span class="secno">4.5.3</span> <span class="content"><span>Should Trusted Type policy creation be blocked by Content Security Policy?</span></span></a>
         <li><a href="#csp-violation-object-hdr"><span class="secno">4.5.4</span> <span class="content">Violation object changes</span></a>
-        <li><a href="#trusted-script-csp-keyword"><span class="secno">4.5.5</span> <span class="content">'trusted-script' keyword</span></a>
+        <li>
+         <a href="#trusted-script-csp-keyword"><span class="secno">4.5.5</span> <span class="content">'trusted-script' keyword</span></a>
+         <ol class="toc">
+          <li><a href="#csp-trusted-script-eval"><span class="secno">4.5.5.1</span> <span class="content">'trusted-script' support for eval</span></a>
+          <li><a href="#csp-trusted-script-javascript-url"><span class="secno">4.5.5.2</span> <span class="content">'trusted-script' support for javascript: URLs</span></a>
+         </ol>
         <li><a href="#is-source-exempt-algorithm"><span class="secno">4.5.6</span> <span class="content"><span>IsSourceExempt</span> Algorithm</span></a>
        </ol>
      </ol>
@@ -2795,6 +2800,7 @@ the <var>calleeRealm</var> or <var>callerRealm</var>’s Content-Security-Policy
                      / "'strict-dynamic'" / "'unsafe-hashes'" / "'report-sample'"
                      / "'unsafe-allow-redirects'" <ins>/ "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-trusted-script">'trusted-script'</dfn>"</ins>
 </pre>
+   <h5 class="heading settled" data-level="4.5.5.1" id="csp-trusted-script-eval"><span class="secno">4.5.5.1. </span><span class="content">'trusted-script' support for eval</span><a class="self-link" href="#csp-trusted-script-eval"></a></h5>
    <p>This document modifies the <a href="https://www.w3.org/TR/CSP3/#can-compile-strings">EnsureCSPDoesNotBlockStringCompilation</a> which is reproduced in its entirety below with additions and deletions.</p>
    <p>
     Given two <a href="https://tc39.github.io/ecma262/#realm">realms</a> (<var>callerRealm</var> and <var>calleeRealm</var>), and a 
@@ -2897,8 +2903,16 @@ Is this a feature or a bug?</p>
    <p class="note" role="note"><span>Note:</span> The previous algorithm reports violations via both report-uris where
 callerRealm != calleeRealm.  If <a data-link-type="abstract-op" href="#abstract-opdef-get-trusted-type-compliant-string" id="ref-for-abstract-opdef-get-trusted-type-compliant-string⑧">Get Trusted Type compliant string</a> reports an
 error, it only reports it via its <var>calleeRealm</var>’s report-uri.</p>
+   <h5 class="heading settled" data-level="4.5.5.2" id="csp-trusted-script-javascript-url"><span class="secno">4.5.5.2. </span><span class="content">'trusted-script' support for javascript: URLs</span><a class="self-link" href="#csp-trusted-script-javascript-url"></a></h5>
+   <p>This document modifies the <a href="https://www.w3.org/TR/CSP3/#match-element-to-source-list">Does element match source list for type and source?</a> algorithm, for it to recognize the 'trusted-script' keyword for <code>javascript:</code> navigations.</p>
+   <p>Add the following step after step 1:</p>
+   <ol start="2">
+    <li data-md>
+     <p>If <var>type</var> is <code>"navigation"</code>, <var>list</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for the string "<a data-link-type="grammar" href="#grammardef-trusted-script" id="ref-for-grammardef-trusted-script①"><code>'trusted-script'</code></a>" and <a data-link-type="abstract-op" href="#abstract-opdef-issourceexempt" id="ref-for-abstract-opdef-issourceexempt①">IsSourceExempt</a> algorithm executed on <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a> returns true,
+return <code>"Matches"</code>.</p>
+   </ol>
    <h4 class="heading settled" data-level="4.5.6" id="is-source-exempt-algorithm"><span class="secno">4.5.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-issourceexempt">IsSourceExempt</dfn> Algorithm</span><a class="self-link" href="#is-source-exempt-algorithm"></a></h4>
-   <p>The IsSourceExempt algorithm takes a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP List</a> (<var>cspList</var>) and executes
+   <p>The IsSourceExempt algorithm takes a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list④">CSP List</a> (<var>cspList</var>) and executes
 the following steps:</p>
    <ol>
     <li data-md>
@@ -3390,6 +3404,12 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-windowproxy">4.5.1.1. trusted-types Pre-Navigation check</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-active-document">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-active-document">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-browsing-context">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
@@ -3402,7 +3422,8 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-concept-document-csp-list">3.4. Get Trusted Type compliant string</a>
     <li><a href="#ref-for-concept-document-csp-list①">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-concept-document-csp-list②">4.5.3. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
-    <li><a href="#ref-for-concept-document-csp-list③">4.5.6. IsSourceExempt Algorithm</a>
+    <li><a href="#ref-for-concept-document-csp-list③">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
+    <li><a href="#ref-for-concept-document-csp-list④">4.5.6. IsSourceExempt Algorithm</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-realm-global">
@@ -3412,7 +3433,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-concept-realm-global①">3.4. Get Trusted Type compliant string</a>
     <li><a href="#ref-for-concept-realm-global②">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-concept-realm-global③">4.5.3. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
-    <li><a href="#ref-for-concept-realm-global④">4.5.5. 'trusted-script' keyword</a> <a href="#ref-for-concept-realm-global⑤">(2)</a>
+    <li><a href="#ref-for-concept-realm-global④">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-concept-realm-global⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-innertext">
@@ -3448,7 +3469,8 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
    <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ascii-case-insensitive">4.5.5. 'trusted-script' keyword</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a>
+    <li><a href="#ref-for-ascii-case-insensitive">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a>
+    <li><a href="#ref-for-ascii-case-insensitive②">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
@@ -3468,7 +3490,8 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-list-contain">
    <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-contain">4.5.5. 'trusted-script' keyword</a>
+    <li><a href="#ref-for-list-contain">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-list-contain①">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-html-namespace">
@@ -3527,7 +3550,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-exceptiondef-evalerror">
    <a href="https://heycam.github.io/webidl/#exceptiondef-evalerror">https://heycam.github.io/webidl/#exceptiondef-evalerror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-exceptiondef-evalerror">4.5.5. 'trusted-script' keyword</a>
+    <li><a href="#ref-for-exceptiondef-evalerror">4.5.5.1. 'trusted-script' support for eval</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Exposed">
@@ -3678,6 +3701,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
      <li><span class="dfn-paneled" id="term-for-windoworworkerglobalscope" style="color:initial">WindowOrWorkerGlobalScope</span>
      <li><span class="dfn-paneled" id="term-for-windowproxy" style="color:initial">WindowProxy</span>
+     <li><span class="dfn-paneled" id="term-for-active-document" style="color:initial">active document</span>
      <li><span class="dfn-paneled" id="term-for-browsing-context" style="color:initial">browsing context</span>
      <li><span class="dfn-paneled" id="term-for-concept-document-csp-list" style="color:initial">csp list</span>
      <li><span class="dfn-paneled" id="term-for-concept-realm-global" style="color:initial">global object</span>
@@ -3967,7 +3991,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-trustedscript①①">4.1.6. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-trustedscript①②">4.2. Integration with SVG</a>
     <li><a href="#ref-for-trustedscript①③">4.5.1.1. trusted-types Pre-Navigation check</a>
-    <li><a href="#ref-for-trustedscript①④">4.5.5. 'trusted-script' keyword</a>
+    <li><a href="#ref-for-trustedscript①④">4.5.5.1. 'trusted-script' support for eval</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="trustedscripturl">
@@ -4133,7 +4157,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-default-policy">3.2. Get default policy</a>
     <li><a href="#ref-for-default-policy①">4.5.1. trusted-types directive</a>
     <li><a href="#ref-for-default-policy②">4.5.1.1. trusted-types Pre-Navigation check</a>
-    <li><a href="#ref-for-default-policy③">4.5.5. 'trusted-script' keyword</a> <a href="#ref-for-default-policy④">(2)</a>
+    <li><a href="#ref-for-default-policy③">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-default-policy④">(2)</a>
     <li><a href="#ref-for-default-policy⑤">6.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
@@ -4187,7 +4211,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string③">4.1.5. Enforcement in timer functions</a>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string④">4.1.6. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑤">4.2. Integration with SVG</a>
-    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑥">4.5.5. 'trusted-script' keyword</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑦">(2)</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑧">(3)</a>
+    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑥">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑦">(2)</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑧">(3)</a>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑨">4.5.6. IsSourceExempt Algorithm</a>
    </ul>
   </aside>
@@ -4317,13 +4341,15 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
   <aside class="dfn-panel" data-for="grammardef-trusted-script">
    <b><a href="#grammardef-trusted-script">#grammardef-trusted-script</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-trusted-script">4.5.5. 'trusted-script' keyword</a>
+    <li><a href="#ref-for-grammardef-trusted-script">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-grammardef-trusted-script①">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-issourceexempt">
    <b><a href="#abstract-opdef-issourceexempt">#abstract-opdef-issourceexempt</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-issourceexempt">4.5.5. 'trusted-script' keyword</a>
+    <li><a href="#ref-for-abstract-opdef-issourceexempt">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-abstract-opdef-issourceexempt①">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/dist/spec/index.html
+++ b/dist/spec/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 08c4b0e94d147852f66673459784d3429bb3bda1" name="generator">
+  <meta content="Bikeshed version f7860c06eaec18afc415bf3f4a7b90aee58ca680" name="generator">
   <link href="https://wicg.github.io/trusted-types/dist/spec/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Trusted Types</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-09-03">3 September 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-09-04">4 September 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1564,7 +1564,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>
        <a href="#integration-with-content-security-policy"><span class="secno">4.5</span> <span class="content">Integration with Content Security Policy</span></a>
        <ol class="toc">
-        <li><a href="#trusted-types-csp-directive"><span class="secno">4.5.1</span> <span class="content"><span>trusted-types</span> directive</span></a>
+        <li>
+         <a href="#trusted-types-csp-directive"><span class="secno">4.5.1</span> <span class="content"><span>trusted-types</span> directive</span></a>
+         <ol class="toc">
+          <li><a href="#trusted-types-pre-navigation-check"><span class="secno">4.5.1.1</span> <span class="content"><code>trusted-types</code> Pre-Navigation check</span></a>
+         </ol>
         <li><a href="#should-block-sink-type-mismatch"><span class="secno">4.5.2</span> <span class="content"><span>Should sink type mismatch violation be blocked by Content Security Policy?</span></span></a>
         <li><a href="#should-block-create-policy"><span class="secno">4.5.3</span> <span class="content"><span>Should Trusted Type policy creation be blocked by Content Security Policy?</span></span></a>
         <li><a href="#csp-violation-object-hdr"><span class="secno">4.5.4</span> <span class="content">Violation object changes</span></a>
@@ -2750,6 +2754,45 @@ of being rejected outright.</p>
 <pre class="http">Content-Security-Policy: trusted-types one two default
 </pre>
    </div>
+   <h5 class="heading settled" data-level="4.5.1.1" id="trusted-types-pre-navigation-check"><span class="secno">4.5.1.1. </span><span class="content"><code>trusted-types</code> Pre-Navigation check</span><a class="self-link" href="#trusted-types-pre-navigation-check"></a></h5>
+   <p>Given a <a href="https://fetch.spec.whatwg.org/#concept-request">request</a> (<var>request</var>), a string <var>navigation type</var>, two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing contexts</a> (<var>source</var> and <var>target</var>), and a <a href="https://www.w3.org/TR/CSP3/#content-security-policy-object">policy</a> (<var>policy</var>), this algorithm returns <code>"Blocked"</code> if a navigation violates the <code class="idl"><a data-link-type="idl">trusted-types</a></code> directive’s constraints and <code>"Allowed"</code> otherwise. This constitutes the <code class="idl"><a data-link-type="idl">trusted-types</a></code> directive’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-pre-navigation-check" id="ref-for-directive-pre-navigation-check">pre-navigation check</a>:</p>
+   <p class="note" role="note"><span>Note:</span> This algorithm assures that the code to be executed by a navigation to a <code>javascript:</code> URL will have to pass through a <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy②">default policy</a>’s <code>createScript</code> function, in addition to all other restrictions imposed by other CSP directives.</p>
+   <ol>
+    <li data-md>
+     <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is not <code>"javascript"</code>, return <code>"Allowed"</code> and abort further steps.</p>
+    <li data-md>
+     <p>Let <var>urlString</var> be the result of running the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer">URL serializer</a> on <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①">url</a>.</p>
+    <li data-md>
+     <p>Let <var>encodedScriptSource</var> be the result of removing the leading <code>"javascript:"</code> from <var>urlString</var>.</p>
+    <li data-md>
+     <p>Let <var>defaultPolicy</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-get-default-policy" id="ref-for-abstract-opdef-get-default-policy①">Get default policy</a> algorithm on <var>source</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy②">WindowProxy</a></code>'s <a data-link-type="dfn" href="#window-trusted-type-policy-factory" id="ref-for-window-trusted-type-policy-factory③">trusted type policy factory</a>.</p>
+    <li data-md>
+     <p>If <var>defaultPolicy</var> is <code>null</code>, return <code>"Blocked"</code> and abort further steps.</p>
+    <li data-md>
+     <p>Let <var>covertedScriptSource</var> be the result of executing <a data-link-type="abstract-op" href="#abstract-opdef-create-a-trusted-type" id="ref-for-abstract-opdef-create-a-trusted-type⑤">Create a Trusted Type</a> algorithm, with the following arguments:</p>
+     <ul>
+      <li data-md>
+       <p><var>defaultPolicy</var> as <var>policy</var></p>
+      <li data-md>
+       <p><var>encodedScriptSource</var> as <var>value</var></p>
+      <li data-md>
+       <p><code>"TrustedScript</code> as <var>trustedTypeName</var></p>
+      <li data-md>
+       <p>« <code>"Location.href"</code> » as <var>arguments</var></p>
+     </ul>
+    <li data-md>
+     <p>If <var>convertedScriptSource</var> does not have a type <code class="idl"><a data-link-type="idl" href="#trustedscript" id="ref-for-trustedscript①③">TrustedScript</a></code>, return <code>"Blocked"</code> and abort further steps.</p>
+    <li data-md>
+     <p>Set <var>urlString</var> to be the result of prepending <code>"javascript:"</code> to stringified <var>convertedScriptSource</var>.</p>
+    <li data-md>
+     <p>Let <var>newURL</var> be the result of running the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser" id="ref-for-concept-url-parser">URL parser</a> on <var>urlString</var>. If the parser returns a failure, return <code>"Blocked"</code> and abort further steps.</p>
+    <li data-md>
+     <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url②">url</a> to <var>newURL</var>.</p>
+     <p class="note" role="note"><span>Note:</span> No other CSP directives operate on <code>javascript:</code> URLs in a pre-navigation check. Other directives that check javascript: URLs
+       will operate on the modified URL later, in the <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-inline-check" id="ref-for-directive-inline-check">inline check</a>.</p>
+    <li data-md>
+     <p>Return <code>"Allowed"</code>.</p>
+   </ol>
    <h4 class="heading settled" data-level="4.5.2" id="should-block-sink-type-mismatch"><span class="secno">4.5.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy">Should sink type mismatch violation be blocked by Content Security Policy?</dfn></span><a class="self-link" href="#should-block-sink-type-mismatch"></a></h4>
    <p>Given a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global②">global object</a> (<var>global</var>), a string (<var>sink</var>) and a string (<var>source</var>) this algorithm
 returns <code>"Blocked"</code> if the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑧">injection sink</a> requires a <a data-link-type="dfn" href="#trusted-type" id="ref-for-trusted-type⑤">Trusted Type</a>, and <code>"Allowed"</code> otherwise.</p>
@@ -2866,7 +2909,7 @@ throws an "<code>EvalError</code>" if not:
        <li data-md>
         <p><code>"eval"</code> as <var>sink</var>,</p>
        <li data-md>
-        <p><code class="idl"><a data-link-type="idl" href="#trustedscript" id="ref-for-trustedscript①③">TrustedScript</a></code> as <var>expectedType</var>.</p>
+        <p><code class="idl"><a data-link-type="idl" href="#trustedscript" id="ref-for-trustedscript①④">TrustedScript</a></code> as <var>expectedType</var>.</p>
       </ul>
      </ins>
     <li data-md>
@@ -2934,12 +2977,12 @@ the substring of
      <ins>Return <var>sourceString</var>.</ins>
    </ol>
    <p class="note" role="note"><span>Note:</span> returning <var>sourceString</var> means that the string that gets
-compiled is that returned by any <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy②">default policy</a> in the course of
+compiled is that returned by any <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy③">default policy</a> in the course of
 executing <a data-link-type="abstract-op" href="#abstract-opdef-get-trusted-type-compliant-string" id="ref-for-abstract-opdef-get-trusted-type-compliant-string⑦">Get Trusted Type compliant string</a>.</p>
    <p class="issue" id="issue-e28ea232"><a class="self-link" href="#issue-e28ea232"></a> This depends on a solution to <a href="https://github.com/WICG/trusted-types/issues/144">issue #144</a> like <a href="https://github.com/tc39-transfer/dynamic-code-brand-checks#problem-host-callout-does-not-receive-type-information">TC39 HostBeforeCompile</a></p>
    <p class="issue" id="issue-649f8da4"><a class="self-link" href="#issue-649f8da4"></a> In some cases, the violation "<code>'report-sample'</code>" contain the result of
 applying the default policy to a string argument which differs.
-Specifically when, there is a <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy③">default policy</a>, <var>isExempt</var> is false,
+Specifically when, there is a <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy④">default policy</a>, <var>isExempt</var> is false,
 and <var>source</var> there is a CSP policy for either the <var>callerRealm</var> or <var>callerRealm</var> that disallows "<code>'unsafe-eval'"</code>.
 Is this a feature or a bug?</p>
    <p class="note" role="note"><span>Note:</span> The previous algorithm reports violations via both report-uris where
@@ -3005,7 +3048,7 @@ together.</p>
 NOT interfere with the operation of user-agent features like addons,
 extensions, or bookmarklets. These kinds of features generally advance
 the user’s priority over page authors, as espoused in <a data-link-type="biblio" href="#biblio-html-design-principles">[html-design-principles]</a>. Specifically, extensions SHOULD be able to pass strings
-to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑨">injection sinks</a> without triggering <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy④">default policy</a> execution, violation generation, or the rejection of the value.</p>
+to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink①⑨">injection sinks</a> without triggering <a data-link-type="dfn" href="#default-policy" id="ref-for-default-policy⑤">default policy</a> execution, violation generation, or the rejection of the value.</p>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -3410,6 +3453,12 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-local-scheme">5.1. Cross-document vectors</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-url">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-url">4.5.1.1. trusted-types Pre-Navigation check</a> <a href="#ref-for-concept-request-url①">(2)</a> <a href="#ref-for-concept-request-url②">(3)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-cereactions">
    <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
@@ -3512,6 +3561,13 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <ul>
     <li><a href="#ref-for-windowproxy">4.1.1. Extensions to the Window interface</a>
     <li><a href="#ref-for-windowproxy①">4.1.2. Extensions to the Document interface</a>
+    <li><a href="#ref-for-windowproxy②">4.5.1.1. trusted-types Pre-Navigation check</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-browsing-context">4.5.1.1. trusted-types Pre-Navigation check</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-document-csp-list">
@@ -3623,6 +3679,24 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGURIReference">https://svgwg.org/svg2-draft/types.html#InterfaceSVGURIReference</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGURIReference">4.2. Integration with SVG</a> <a href="#ref-for-InterfaceSVGURIReference①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
+   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-scheme">4.5.1.1. trusted-types Pre-Navigation check</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
+   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-parser">4.5.1.1. trusted-types Pre-Navigation check</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
+   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-serializer">4.5.1.1. trusted-types Pre-Navigation check</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMString">
@@ -3787,6 +3861,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <a data-link-type="biblio">[Fetch]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-local-scheme" style="color:initial">local scheme</span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-url" style="color:initial">url</span>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
@@ -3807,6 +3882,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
      <li><span class="dfn-paneled" id="term-for-windoworworkerglobalscope" style="color:initial">WindowOrWorkerGlobalScope</span>
      <li><span class="dfn-paneled" id="term-for-windowproxy" style="color:initial">WindowProxy</span>
+     <li><span class="dfn-paneled" id="term-for-browsing-context" style="color:initial">browsing context</span>
      <li><span class="dfn-paneled" id="term-for-concept-document-csp-list" style="color:initial">csp list</span>
      <li><span class="dfn-paneled" id="term-for-concept-realm-global" style="color:initial">global object</span>
      <li><span class="dfn-paneled" id="term-for-dom-innertext" style="color:initial">innerText</span>
@@ -3831,6 +3907,13 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><span class="dfn-paneled" id="term-for-InterfaceSVGElement" style="color:initial">SVGElement</span>
      <li><span class="dfn-paneled" id="term-for-InterfaceSVGScriptElement" style="color:initial">SVGScriptElement</span>
      <li><span class="dfn-paneled" id="term-for-InterfaceSVGURIReference" style="color:initial">SVGURIReference</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[URL]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-concept-url-scheme" style="color:initial">scheme</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url-parser" style="color:initial">url parser</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url-serializer" style="color:initial">url serializer</span>
     </ul>
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
@@ -3875,6 +3958,8 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-svg2">[SVG2]
    <dd>Amelia Bellamy-Royds; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 4 October 2018. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
+   <dt id="biblio-url">[URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WebIDL]
    <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
@@ -3931,7 +4016,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
 <c- b>interface</c-> <a href="#trustedtypepolicy"><code><c- g>TrustedTypePolicy</c-></code></a> {
   [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑦①"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①①"><c- b>DOMString</c-></a> <a data-readonly data-type="DOMString" href="#dom-trustedtypepolicy-name"><code><c- g>name</c-></code></a>;
   [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑧①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedhtml" id="ref-for-trustedhtml⑤①"><c- n>TrustedHTML</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createhtml" id="ref-for-dom-trustedtypepolicy-createhtml①"><c- g>createHTML</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①②①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createhtml-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createhtml-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑨①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript①④"><c- n>TrustedScript</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscript" id="ref-for-dom-trustedtypepolicy-createscript②"><c- g>createScript</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①③①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createscript-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createscript-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable⑨①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscript" id="ref-for-trustedscript①⑤"><c- n>TrustedScript</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscript" id="ref-for-dom-trustedtypepolicy-createscript②"><c- g>createScript</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①③①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createscript-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createscript-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
   [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①⓪①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedscripturl" id="ref-for-trustedscripturl①①"><c- n>TrustedScriptURL</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createscripturl" id="ref-for-dom-trustedtypepolicy-createscripturl②"><c- g>createScriptURL</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①④①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createscripturl-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createscripturl-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
   [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①①①"><c- g>Unforgeable</c-></a>] <a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl①⑨"><c- n>TrustedURL</c-></a> <a class="idl-code" data-link-type="method" href="#dom-trustedtypepolicy-createurl" id="ref-for-dom-trustedtypepolicy-createurl②"><c- g>createURL</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑤①"><c- b>DOMString</c-></a> <a href="#dom-trustedtypepolicy-createurl-input-arguments-input"><code><c- g>input</c-></code></a>, <c- b>any</c->... <a href="#dom-trustedtypepolicy-createurl-input-arguments-arguments"><code><c- g>arguments</c-></code></a>);
 };
@@ -3959,7 +4044,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Unforgeable" id="ref-for-Unforgeable①②①"><c- g>Unforgeable</c-></a>] <c- b>readonly</c-> <c- b>attribute</c->
       <a class="n" data-link-type="idl-name" href="#trustedtypepolicyfactory" id="ref-for-trustedtypepolicyfactory③①"><c- n>TrustedTypePolicyFactory</c-></a> <a data-readonly data-type="TrustedTypePolicyFactory" href="#dom-window-trustedtypes"><code><c- g>trustedTypes</c-></code></a>;
 
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy②"><c- n>WindowProxy</c-></a>? <a href="#dom-window-open"><code><c- g>open</c-></code></a>(
+  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#windowproxy" id="ref-for-windowproxy③"><c- n>WindowProxy</c-></a>? <a href="#dom-window-open"><code><c- g>open</c-></code></a>(
       [<a class="idl-code" data-link-type="extended-attribute" href="#extendedattrdef-trustedtypes" id="ref-for-extendedattrdef-trustedtypes⑦①"><c- g>TrustedTypes</c-></a>=<a class="n" data-link-type="idl-name" href="#trustedurl" id="ref-for-trustedurl⑤①"><c- n>TrustedURL</c-></a>] <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#typedefdef-urlstring" id="ref-for-typedefdef-urlstring①④"><c- n>URLString</c-></a> <a href="#dom-window-open-url-target-features-url"><code><c- g>url</c-></code></a> = "about:blank",
       <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑤①"><c- b>DOMString</c-></a> <a href="#dom-window-open-url-target-features-target"><code><c- g>target</c-></code></a> = "_blank",
       <c- b>optional</c-> ([<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#TreatNullAs" id="ref-for-TreatNullAs①①"><c- g>TreatNullAs</c-></a>=<a class="n" data-link-type="idl-name"><c- n>EmptyString</c-></a>] <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑥①"><c- b>DOMString</c-></a>) <a href="#dom-window-open-url-target-features-features"><code><c- g>features</c-></code></a> = "");
@@ -4140,7 +4225,8 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-trustedscript⑨">4.1.6. Enforcement in timer functions</a> <a href="#ref-for-trustedscript①⓪">(2)</a>
     <li><a href="#ref-for-trustedscript①①">4.1.7. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-trustedscript①②">4.2. Integration with SVG</a>
-    <li><a href="#ref-for-trustedscript①③">4.5.5. 'trusted-script' keyword</a>
+    <li><a href="#ref-for-trustedscript①③">4.5.1.1. trusted-types Pre-Navigation check</a>
+    <li><a href="#ref-for-trustedscript①④">4.5.5. 'trusted-script' keyword</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="trustedscripturl">
@@ -4345,8 +4431,9 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-default-policy">3.2. Get default policy</a>
     <li><a href="#ref-for-default-policy①">4.5.1. trusted-types directive</a>
-    <li><a href="#ref-for-default-policy②">4.5.5. 'trusted-script' keyword</a> <a href="#ref-for-default-policy③">(2)</a>
-    <li><a href="#ref-for-default-policy④">6.1. Vendor-specific Extensions and Addons</a>
+    <li><a href="#ref-for-default-policy②">4.5.1.1. trusted-types Pre-Navigation check</a>
+    <li><a href="#ref-for-default-policy③">4.5.5. 'trusted-script' keyword</a> <a href="#ref-for-default-policy④">(2)</a>
+    <li><a href="#ref-for-default-policy⑤">6.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enforcement">
@@ -4382,6 +4469,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
    <b><a href="#abstract-opdef-get-default-policy">#abstract-opdef-get-default-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-get-default-policy">3.4. Get Trusted Type compliant string</a>
+    <li><a href="#ref-for-abstract-opdef-get-default-policy①">4.5.1.1. trusted-types Pre-Navigation check</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-create-a-trusted-type">
@@ -4389,6 +4477,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-abstract-opdef-create-a-trusted-type">2.3.2. TrustedTypePolicy</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type①">(2)</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type②">(3)</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type③">(4)</a>
     <li><a href="#ref-for-abstract-opdef-create-a-trusted-type④">3.4. Get Trusted Type compliant string</a>
+    <li><a href="#ref-for-abstract-opdef-create-a-trusted-type⑤">4.5.1.1. trusted-types Pre-Navigation check</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-get-trusted-type-compliant-string">
@@ -4454,6 +4543,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
    <ul>
     <li><a href="#ref-for-window-trusted-type-policy-factory">2.4.2. TrustedTypes extended attribute</a> <a href="#ref-for-window-trusted-type-policy-factory①">(2)</a>
     <li><a href="#ref-for-window-trusted-type-policy-factory②">3.4. Get Trusted Type compliant string</a>
+    <li><a href="#ref-for-window-trusted-type-policy-factory③">4.5.1.1. trusted-types Pre-Navigation check</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-window-trustedtypes">

--- a/dist/spec/index.html
+++ b/dist/spec/index.html
@@ -1677,8 +1677,8 @@ templating policy and enables the enforcement for the DOM sinks.</p>
     <li data-md>
      <p>An existing web application interacts with the DOM mostly using XSS-safe
 patterns (i.e. withour using <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink">injection sinks</a>). In a few places, however,
-it resorts to using risky patterns like calling into <code>innerHTML</code>, <code>eval</code>, or
-creating <code>javascript:</code> URIs.</p>
+it resorts to using risky patterns like loading additional script using
+JSONP, calling into <code>innerHTML</code> or <code>eval</code>.</p>
      <p>Review finds that those places do not cause XSS (e.g. because
 user-controlled data is not part of the input to those sinks), but it’s
 hard to migrate the application off using these patterns.</p>
@@ -1709,19 +1709,19 @@ string value in a way that could result in XSS if that value is untrusted.</p>
    <p>Examples of injection sinks include:</p>
    <ul>
     <li data-md>
-     <p>Functions that parse &amp; insert HTML strings into the document like <a href="https://www.w3.org/TR/DOM-Parsing/#widl-Element-innerHTML">Element.innerHTML</a> setter</p>
+     <p>Functions that parse &amp; insert HTML strings into the document like <a href="https://www.w3.org/TR/DOM-Parsing/#widl-Element-innerHTML">Element.innerHTML</a> setter,</p>
     <li data-md>
      <p>Setters for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> attributes that accept a URL of the code to load
-like <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-htmlscriptelement-src" id="ref-for-dom-htmlscriptelement-src">HTMLScriptElement.src</a></code></p>
+like <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-htmlscriptelement-src" id="ref-for-dom-htmlscriptelement-src">HTMLScriptElement.src</a></code>,</p>
     <li data-md>
-     <p>Setters for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code> attributes that accept a code to execute like <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-htmlscriptelement-text" id="ref-for-dom-htmlscriptelement-text">HTMLScriptElement.text</a></code></p>
+     <p>Setters for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code> attributes that accept a code to execute like <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-htmlscriptelement-text" id="ref-for-dom-htmlscriptelement-text">HTMLScriptElement.text</a></code>,</p>
     <li data-md>
-     <p>Functions that execute code directly like <code>eval</code>.</p>
-    <li data-md>
-     <p>Functions that accept URLs with <code>javascript:</code> scheme</p>
+     <p>Functions that execute code directly like <code>eval</code>,</p>
     <li data-md>
      <p>Functions that create a new same-origin <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> with caller-controlled
-markup like <code class="idl"><a data-link-type="idl" href="#dom-domparser-parsefromstring" id="ref-for-dom-domparser-parsefromstring">parseFromString()</a></code>.</p>
+markup like <code class="idl"><a data-link-type="idl" href="#dom-domparser-parsefromstring" id="ref-for-dom-domparser-parsefromstring">parseFromString()</a></code>,</p>
+    <li data-md>
+     <p>Navigation to 'javascript:' URLs.</p>
    </ul>
    <p>An application is vulnerable to DOM XSS if it permits a flow of data from an
 attacker-controlled source and permits that data to reach an injection sink

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -105,8 +105,8 @@ which are substantially easier to safeguard, monitor and review.
 
 *   An existing web application interacts with the DOM mostly using XSS-safe
     patterns (i.e. withour using [=injection sinks=]). In a few places, however,
-    it resorts to using risky patterns like calling into `innerHTML`, `eval`, or
-    creating `javascript:` URIs.
+    it resorts to using risky patterns like loading additional script using
+    JSONP, calling into `innerHTML` or `eval`.
 
     Review finds that those places do not cause XSS (e.g. because
     user-controlled data is not part of the input to those sinks), but it's
@@ -146,15 +146,15 @@ string value in a way that could result in XSS if that value is untrusted.
 Examples of injection sinks include:
 
   * Functions that parse & insert HTML strings into the document like
-    [[DOM-Parsing#widl-Element-innerHTML|Element.innerHTML]] setter
+    [[DOM-Parsing#widl-Element-innerHTML|Element.innerHTML]] setter,
   * Setters for {{Element}} attributes that accept a URL of the code to load
-    like {{HTMLScriptElement/src!!attribute|HTMLScriptElement.src}}
+    like {{HTMLScriptElement/src!!attribute|HTMLScriptElement.src}},
   * Setters for {{Element}} attributes that accept a code to execute like
-    {{HTMLScriptElement/text!!attribute|HTMLScriptElement.text}}
-  * Functions that execute code directly like `eval`.
-  * Functions that accept URLs with `javascript:` scheme
+    {{HTMLScriptElement/text!!attribute|HTMLScriptElement.text}},
+  * Functions that execute code directly like `eval`,
   * Functions that create a new same-origin {{Document}} with caller-controlled
-    markup like {{DOMParser/parseFromString()}}.
+    markup like {{DOMParser/parseFromString()}},
+  * Navigation to 'javascript:' URLs.
 
 An application is vulnerable to DOM XSS if it permits a flow of data from an
 attacker-controlled source and permits that data to reach an injection sink

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -268,29 +268,6 @@ To stringify a TrustedScriptURL object, return the USVString from its
 `[[Data]]` internal slot.
 
 
-### <dfn type>TrustedURL</dfn> ### {#trusted-url}
-
-The TrustedURL interface represents a string that a developer
-can confidently pass into an [=injection sink=] that may cause
-navigation to that URL string.
-These objects are immutable wrappers around a
-string, constructed via a {{TrustedTypePolicy}}'s
-{{TrustedTypePolicy/createURL(input)|createURL}} method.
-
-<pre class="idl">
-[Exposed=Window]
-interface TrustedURL {
-  stringifier;
-};
-</pre>
-
-TrustedURL objects have a `[[Data]]` internal slot which holds a
-USVString.  The slot's value is set when the object is created, and
-will never change during its lifetime.
-
-To stringify a TrustedURL object, return the USVString from its
-`[[Data]]` internal slot.
-
 ## Policies ## {#policies}
 
 Trusted Types can only be created via user-defined
@@ -404,7 +381,6 @@ reference - see [[#extensions-to-the-window-interface]].
     [Unforgeable] boolean isHTML(any value);
     [Unforgeable] boolean isScript(any value);
     [Unforgeable] boolean isScriptURL(any value);
-    [Unforgeable] boolean isURL(any value);
     [Unforgeable] readonly attribute TrustedHTML emptyHTML;
     DOMString? getAttributeType(
         DOMString tagName,
@@ -524,9 +500,6 @@ initially empty.
 : <dfn>isScriptURL(value)</dfn>
 :: Returns true if value is an instance of {{TrustedScriptURL}} and has its `[[Data]]` internal slot set, false otherwise.
 
-: <dfn>isURL(value)</dfn>
-:: Returns true if value is an instance of {{TrustedURL}} and has its `[[Data]]` internal slot set, false otherwise.
-
 : <dfn>getPropertyType(tagName, property, elementNs)</dfn>
 :: Allows the authors to check if a Trusted Type is required for a given [=Element=]'s
     property (IDL attribute).
@@ -548,7 +521,6 @@ initially empty.
     <div class="example" id="get-property-type-example">
     <xmp highlight="js">
     trustedTypes.getPropertyType('div', 'innerHTML'); // "TrustedHTML"
-    trustedTypes.getPropertyType('form', 'formAction'); // "TrustedURL"
     trustedTypes.getPropertyType('foo', 'bar'); // undefined
     </xmp>
     </div>
@@ -575,9 +547,8 @@ initially empty.
 
     <div class="example" id="get-attribute-type-example">
     <xmp highlight="js">
-    trustedTypes.getPropertyType('a', 'HREF'); // "TrustedURL"
-    trustedTypes.getPropertyType('form', 'formaction'); // "TrustedURL"
-    trustedTypes.getPropertyType('foo', 'bar'); // undefined
+    trustedTypes.getAttributeType('script', 'SRC'); // "TrustedScriptURL"
+    trustedTypes.getAttributeType('foo', 'bar'); // undefined
     </xmp>
     </div>
 
@@ -621,7 +592,6 @@ interface TrustedTypePolicy {
   [Unforgeable] TrustedHTML createHTML(DOMString input, any... arguments);
   [Unforgeable] TrustedScript createScript(DOMString input, any... arguments);
   [Unforgeable] TrustedScriptURL createScriptURL(DOMString input, any... arguments);
-  [Unforgeable] TrustedURL createURL(DOMString input, any... arguments);
 };
 </pre>
 
@@ -677,23 +647,6 @@ Each TrustedTypePolicy object has an `[[options]]` internal slot, holding the {{
       <dd>arguments</dd>
     </dl>
 
-
-: <dfn>createURL(input, ...arguments)</dfn>
-::  Returns the
-    result of executing the [$Create a Trusted Type$] algorithm, with the
-    following arguments:
-    <dl>
-      <dt>policy</dt>
-      <dd>[[DOM#context-object|context object]]</dt>
-      <dt>trustedTypeName</dt>
-      <dd>`"TrustedURL"`</dd>
-      <dt>value</dt>
-      <dd>input</dd>
-      <dt>arguments</dt>
-      <dd>arguments</dd>
-    </dl>
-
-
 </div>
 
 ### <dfn type>TrustedTypePolicyOptions</dfn> ### {#trusted-type-policy-options}
@@ -707,12 +660,10 @@ object instances directly - this behavior is provided by
 dictionary TrustedTypePolicyOptions {
    CreateHTMLCallback? createHTML;
    CreateScriptCallback? createScript;
-   CreateURLCallback? createURL;
    CreateScriptURLCallback? createScriptURL;
 };
 callback CreateHTMLCallback = DOMString (DOMString input);
 callback CreateScriptCallback = DOMString (DOMString input);
-callback CreateURLCallback = USVString (DOMString input);
 callback CreateScriptURLCallback = USVString (DOMString input);
 </pre>
 
@@ -803,7 +754,7 @@ IDL [=extended attributes|extended attribute=]. Its presence indicates that the 
 Trusted Types enforcement logic.
 
 The {{TrustedTypes}} extended attribute [=extended attribute/takes an identifier=] as an argument.
-The only valid values for the identifier are {{TrustedHTML}}, {{TrustedScript}}, {{TrustedScriptURL}} or {{TrustedURL}}.
+The only valid values for the identifier are {{TrustedHTML}}, {{TrustedScript}}, or {{TrustedScriptURL}}.
 This extended attribute must not appear on anything other than an [=attribute=] or an [=operation=] argument.
 Additionally, it must not appear on [=read only=] attributes.
 
@@ -817,15 +768,15 @@ When the extended attribute appears on an attribute, the setter for that attribu
         <div class="example" id="extended-attribute-attribute-example">
         For example, the following annotation and JavaScript code:
         <pre highlight=idl>
-        partial interface mixin HTMLHyperlinkElementUtils {
-          [CEReactions, TrustedTypes=TrustedURL] stringifier attribute URLString href;
+        partial interface mixin HTMLScriptElement {
+          [CEReactions, TrustedTypes=TrustedScriptURL] attribute ScriptURLString src;
         };
         </pre>
         <pre highlight=js>
-        document.createElement('a').href = foo;
-        document.createElement('a').setAttribute('HREF', foo);
+        document.createElement('script').src = foo;
+        document.createElement('script').setAttribute('SrC', foo);
         </pre>
-        causes the |sink| value to be `"a.href"`.
+        causes the |sink| value to be `"script.src"`.
         </div>
     1. Set |value| to the result of running the [$Get Trusted Type compliant string$] algorithm, passing the following arguments:
         * the new value as |input|,
@@ -888,9 +839,6 @@ a string (|policyName|), {{TrustedTypePolicyOptions}} dictionary (|options|), an
 1.  Set |policyOptions| {{TrustedTypePolicy/createScriptURL()|createScriptURL}}
     property to |option|'s
     {{TrustedTypePolicyOptions/createScriptURL|createScriptURL}} property value.
-1.  Set |policyOptions| {{TrustedTypePolicy/createURL()|createURL}}
-    property to |option|'s
-    {{TrustedTypePolicyOptions/createURL|createURL}} property value.
 1.  Set |policy|'s `[[options]]` internal slot value to *policyOptions*.
 1.  If the |policyName| is `default`, set the |factory|'s `[[DefaultPolicy]]` slot value to |policy|.
 1.  Append |policyName| to |factory|'s `[[CreatedPolicyNames]]`.
@@ -926,10 +874,6 @@ a string |value| and a list |arguments|, execute the following steps:
       <tr>
         <td>"createScriptURL"</td>
         <td>"TrustedScriptURL"</td>
-      </tr>
-      <tr>
-        <td>"createURL"</td>
-        <td>"TrustedURL"</td>
       </tr>
     </table>
 
@@ -989,8 +933,7 @@ Given a {{TrustedType}} type (|expectedType|), a [=Realm/global object=] (|globa
 typedef (DOMString or TrustedHTML) HTMLString;
 typedef (DOMString or TrustedScript) ScriptString;
 typedef (USVString or TrustedScriptURL) ScriptURLString;
-typedef (USVString or TrustedURL) URLString;
-typedef (TrustedHTML or TrustedScript or TrustedScriptURL or TrustedURL) TrustedType;
+typedef (TrustedHTML or TrustedScript or TrustedScriptURL) TrustedType;
 
 typedef (([TreatNullAs=EmptyString] DOMString) or TrustedHTML) HTMLStringDefaultsEmpty;
 </pre>
@@ -1019,11 +962,6 @@ This document extends the {{Window}} interface defined by [[HTML5|HTML]]:
 partial interface mixin Window {
   [Unforgeable] readonly attribute
       TrustedTypePolicyFactory trustedTypes;
-
-  WindowProxy? open(
-      [TrustedTypes=TrustedURL] optional URLString url = "about:blank",
-      optional DOMString target = "_blank",
-      optional ([TreatNullAs=EmptyString] DOMString) features = "");
 };
 </pre>
 
@@ -1041,24 +979,8 @@ This document modifies the {{Document}} interface defined by [[HTML5|HTML]]:
 
 <pre class="idl">
 partial interface mixin Document {
-  WindowProxy? open([TrustedTypes=TrustedURL] URLString url, DOMString name, DOMString features);
   [CEReactions] void write([TrustedTypes=TrustedHTML] HTMLString... text);
   [CEReactions] void writeln([TrustedTypes=TrustedHTML] HTMLString... text);
-};
-</pre>
-
-Note: This document does not affect the two argument form of
-[[HTML/dynamic-markup-insertion#dom-document-open|document.open]].
-
-### Extensions to the Location interface ### {#extensions-to-the-location-interface}
-
-This document modifies the {{Location}} interface defined by [[HTML5|HTML]]:
-
-<pre class="idl">
-partial interface mixin Location {
-  [Unforgeable, TrustedTypes=TrustedURL] stringifier attribute URLString href;
-  [Unforgeable] void assign([TrustedTypes=TrustedURL] URLString url);
-  [Unforgeable] void replace([TrustedTypes=TrustedURL] URLString url);
 };
 </pre>
 
@@ -1073,7 +995,6 @@ partial interface mixin HTMLScriptElement : HTMLElement {
 };
 
 partial interface mixin HTMLIFrameElement : HTMLElement {
-  [CEReactions, TrustedTypes=TrustedURL] attribute URLString src;
   [CEReactions, TrustedTypes=TrustedHTML] attribute HTMLString srcdoc;
 };
 
@@ -1086,33 +1007,10 @@ partial interface HTMLObjectElement : HTMLElement {
   [CEReactions, TrustedTypes=TrustedScriptURL] attribute DOMString codeBase; // obsolete
 };
 
-partial interface HTMLFrameElement : HTMLElement { // obsolete
-  [CEReactions, TrustedTypes=TrustedURL] attribute URLString src;
-};
-
-partial interface HTMLFormElement : HTMLElement {
-  [CEReactions, TrustedTypes=TrustedURL] attribute URLString action;
-};
-
-partial interface HTMLInputElement : HTMLElement {
-  [CEReactions, TrustedTypes=TrustedURL] attribute URLString formAction;
-  [CEReactions, TrustedTypes=TrustedURL] attribute URLString src;
-};
-
-partial interface HTMLButtonElement : HTMLElement {
-  [CEReactions, TrustedTypes=TrustedURL] attribute URLString formAction;
-};
-
-partial interface mixin HTMLHyperlinkElementUtils {
-  [CEReactions, TrustedTypes=TrustedURL] stringifier attribute URLString href;
-};
-
-partial interface HTMLBaseElement : HTMLElement {
-  [CEReactions, TrustedTypes=TrustedURL] attribute URLString href;
-};
-
 // TODO: Add HTMLPortalElement.src from https://github.com/WICG/portals once it's specced.
 </pre>
+
+Issue: Add base.href enforcement.
 
 ### Enforcement for script text contents ### {#enforcement-in-script-text}
 
@@ -1213,13 +1111,9 @@ Note: This also applies to events in [[SVG2#EventAttributes]].
 
 ## Integration with SVG ## {#integration-with-svg}
 
-This document modifies the {{SVGScriptElement}} interface and {{SVGURIReference}} interfaces to enforce Trusted Types on those:
+This document modifies the {{SVGScriptElement}} interface to enforce Trusted Types:
 
 <pre class="idl">
-partial interface SVGURIReference {
-  [SameObject, TrustedTypes=TrustedURL] readonly attribute SVGAnimatedString href;
-};
-
 partial interface mixin SVGScriptElement : SVGElement {
  // overwrites the definition in SVGURIReference.
  [TrustedTypes=TrustedScriptURL] readonly attribute ScriptURLString href;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1343,6 +1343,8 @@ This document modifies the grammar for [[CSP3#keyword-source]]:
                        / "'unsafe-allow-redirects'" <ins>/ "<dfn>'trusted-script'</dfn>"</ins>
 </pre>
 
+#### 'trusted-script' support for eval #### {#csp-trusted-script-eval}
+
 This document modifies the [[CSP3#can-compile-strings|EnsureCSPDoesNotBlockStringCompilation]]
 which is reproduced in its entirety below with additions and deletions.
 
@@ -1424,6 +1426,17 @@ Is this a feature or a bug?
 Note: The previous algorithm reports violations via both report-uris where
 callerRealm != calleeRealm.  If [$Get Trusted Type compliant string$] reports an
 error, it only reports it via its |calleeRealm|'s report-uri.
+
+#### 'trusted-script' support for javascript: URLs #### {#csp-trusted-script-javascript-url}
+
+This document modifies the [[CSP3#match-element-to-source-list|Does element match source list for type and source?]]
+algorithm, for it to recognize the 'trusted-script' keyword for `javascript:` navigations.
+
+Add the following step after step 1:
+
+2.  If |type| is `"navigation"`, |list| [=list/contains=] an [=ASCII case-insensitive=]
+    match for the string "<a grammar>`'trusted-script'`</a>" and [$IsSourceExempt$] algorithm executed on [=active document=]'s <a>CSP list</a> returns true,
+    return `"Matches"`.
 
 
 ### <dfn abstract-op>IsSourceExempt</dfn> Algorithm ### {#is-source-exempt-algorithm}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1330,6 +1330,37 @@ Content-Security-Policy: trusted-types one two default
 </pre>
 </div>
 
+#### `trusted-types` Pre-Navigation check #### {#trusted-types-pre-navigation-check}
+
+Given a [[Fetch#concept-request|request]] (|request|), a string |navigation type|, two [=browsing contexts=]
+(|source| and |target|), and a [[CSP3#content-security-policy-object|policy]] (|policy|), this algorithm returns `"Blocked"`
+if a navigation violates the {{#trusted-types-directive|trusted-types}} directive's constraints and `"Allowed"`
+otherwise. This constitutes the {{#trusted-types-directive|trusted-types}} directive's [=pre-navigation check=]:
+
+Note: This algorithm assures that the code to be executed by a navigation to a `javascript:` URL will have to pass through a
+<a>default policy</a>'s `createScript` function, in addition to all other restrictions imposed by other CSP directives.
+
+1. If |request|'s [=request/url=]'s [=url/scheme=] is not `"javascript"`, return `"Allowed"` and abort further steps.
+1. Let |urlString| be the result of running the [=URL serializer=] on |request|'s [=request/url=].
+1. Let |encodedScriptSource| be the result of removing the leading `"javascript:"` from |urlString|.
+1. Let |defaultPolicy| be the result of executing [$Get default policy$] algorithm on |source|'s {{WindowProxy}}'s [=trusted type policy factory=].
+1. If |defaultPolicy| is `null`, return `"Blocked"` and abort further steps.
+1. Let |covertedScriptSource| be the result of executing [$Create a Trusted Type$] algorithm, with the following arguments:
+
+    * |defaultPolicy| as |policy|
+    * |encodedScriptSource| as |value|
+    * `"TrustedScript` as |trustedTypeName|
+    * &laquo; `"Location.href"` &raquo; as |arguments|
+1. If |convertedScriptSource| does not have a type {{TrustedScript}}, return `"Blocked"` and abort further steps.
+1. Set |urlString| to be the result of prepending `"javascript:"` to stringified |convertedScriptSource|.
+1. Let |newURL| be the result of running the [=URL parser=] on |urlString|. If the parser returns a failure, return `"Blocked"` and abort further steps.
+1. Set |request|'s [=request/url=] to |newURL|.
+
+     Note: No other CSP directives operate on `javascript:` URLs in a pre-navigation check. Other directives that check javascript: URLs
+           will operate on the modified URL later, in the [=inline check=].
+1. Return `"Allowed"`.
+
+
 ### <dfn abstract-op>Should sink type mismatch violation be blocked by Content Security Policy?</dfn> ### {#should-block-sink-type-mismatch}
 
 Given a [=Realm/global object=] (|global|), a string (|sink|) and a string (|source|) this algorithm

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1239,13 +1239,13 @@ Note: This algorithm assures that the code to be executed by a navigation to a `
 1. Let |encodedScriptSource| be the result of removing the leading `"javascript:"` from |urlString|.
 1. Let |defaultPolicy| be the result of executing [$Get default policy$] algorithm on |source|'s {{WindowProxy}}'s [=trusted type policy factory=].
 1. If |defaultPolicy| is `null`, return `"Blocked"` and abort further steps.
-1. Let |covertedScriptSource| be the result of executing [$Create a Trusted Type$] algorithm, with the following arguments:
+1. Let |convertedScriptSource| be the result of executing [$Create a Trusted Type$] algorithm, with the following arguments:
 
     * |defaultPolicy| as |policy|
     * |encodedScriptSource| as |value|
     * `"TrustedScript` as |trustedTypeName|
     * &laquo; `"Location.href"` &raquo; as |arguments|
-1. If |convertedScriptSource| does not have a type {{TrustedScript}}, return `"Blocked"` and abort further steps.
+1. If |convertedScriptSource| is not a {{TrustedScript}} object, return `"Blocked"` and abort further steps.
 1. Set |urlString| to be the result of prepending `"javascript:"` to stringified |convertedScriptSource|.
 1. Let |newURL| be the result of running the [=URL parser=] on |urlString|. If the parser returns a failure, return `"Blocked"` and abort further steps.
 1. Set |request|'s [=request/url=] to |newURL|.


### PR DESCRIPTION
This removes the burden from all authors to create types when interacting with common sinks that usually don't cause DOM XSS (unless for javascript: URLs).

This PR prevents `javascript:` URLs from working by default, and allows programmatic opt-in to enable them one-by-onefor the few applications that need them.

Related to #176. 
Partially addresses #169.
Fixes #64.
